### PR TITLE
Prevent sample from being skipped

### DIFF
--- a/src/wavbank.cpp
+++ b/src/wavbank.cpp
@@ -236,7 +236,7 @@ struct WavBank : Module
 		}
 		else
 		{
-			selected_sample->run = false;
+			//selected_sample->run = false; // This cause sample not to ever play again in this instance
 			outputs[WAV_OUTPUT].setVoltage(0);
 		}
 	}


### PR DESCRIPTION
I found that samples were randomly not playing. I'm not sure if this line has another use, so I just commented it out, but doing so fix the issue. 