### PR TITLE
Feature/wavbank

### DIFF
--- a/src/ghosts.cpp
+++ b/src/ghosts.cpp
@@ -5,77 +5,12 @@
 
 #include "plugin.hpp"
 #include "osdialog.h"
-#include "dr_wav.h"
-#include <vector>
 #include "cmath"
 #include <memory>
+#include "sample.hpp"
 
-using namespace std;
 #define MAX_GRAVEYARD_CAPACITY 128.0f
 #define MAX_GHOST_SPAWN_RATE 12000.0f
-
-struct Sample
-{
-	std::string path;
-	std::string filename;
-	drwav_uint64 total_sample_count;
-	bool loading;
-	vector<float> playBuffer;
-	unsigned int sample_rate;
-	unsigned int channels;
-	bool run = false;
-
-	Sample()
-	{
-		playBuffer.resize(0);
-		total_sample_count = 0;
-		loading = false;
-		filename = "[ empty ]";
-		path = "";
-		sample_rate = 0;
-		channels = 0;
-	}
-
-	void load(std::string path)
-	{
-		this->loading = true;
-
-		unsigned int reported_channels;
-		unsigned int reported_sample_rate;
-		drwav_uint64 reported_total_sample_count;
-		float *pSampleData;
-
-		pSampleData = drwav_open_and_read_file_f32(path.c_str(), &reported_channels, &reported_sample_rate, &reported_total_sample_count);
-
-		if (pSampleData != NULL)
-		{
-			// I'm aware that the "this" pointer isn't necessary here, but I wanted to include
-			// it just to make the code as clear as possible.
-
-			this->channels = reported_channels;
-			this->sample_rate = reported_sample_rate;
-			this->playBuffer.clear();
-
-			for (unsigned int i=0; i < reported_total_sample_count; i = i + this->channels)
-			{
-				this->playBuffer.push_back(pSampleData[i]);
-			}
-
-			drwav_free(pSampleData);
-
-			this->total_sample_count = playBuffer.size();
-			this->filename = rack::string::filename(path);
-			this->path = path;
-
-			this->loading = false;
-			this->run = true;
-		}
-		else
-		{
-			this->loading = false;
-		}
-	};
-};
 
 struct Ghost
 {
@@ -129,7 +64,7 @@ struct Ghost
 			sample_position = sample_position % this->sample_ptr->total_sample_count;
 		}
 
-		output_voltage = this->sample_ptr->playBuffer[sample_position];
+		output_voltage = this->sample_ptr->leftPlayBuffer[sample_position];
 
 		if(loop_smoothing_ramp < 1)
 		{
@@ -181,7 +116,7 @@ struct Ghosts : Module
 	std::string root_dir;
 	std::string path;
 
-	vector<Ghost> graveyard;
+	std::vector<Ghost> graveyard;
 	Sample sample;
 	dsp::SchmittTrigger purge_trigger;
 	dsp::SchmittTrigger purge_button_trigger;

--- a/src/ghosts.cpp
+++ b/src/ghosts.cpp
@@ -5,8 +5,6 @@
 
 #include "plugin.hpp"
 #include "osdialog.h"
-#include "cmath"
-#include <memory>
 #include "sample.hpp"
 
 #define MAX_GRAVEYARD_CAPACITY 128.0f

--- a/src/goblins.cpp
+++ b/src/goblins.cpp
@@ -5,8 +5,6 @@
 
 #include "plugin.hpp"
 #include "osdialog.h"
-#include "cmath"
-#include <memory>
 #include "sample.hpp"
 
 #define MAX_NUMBER_OF_GOBLINS 128.0f

--- a/src/goblins.cpp
+++ b/src/goblins.cpp
@@ -5,79 +5,14 @@
 
 #include "plugin.hpp"
 #include "osdialog.h"
-#include "dr_wav.h"
-#include <vector>
 #include "cmath"
 #include <memory>
+#include "sample.hpp"
 
-using namespace std;
 #define MAX_NUMBER_OF_GOBLINS 128.0f
 #define MAX_SPAWN_RATE 12000.0f
 #define NUMBER_OF_SAMPLES 5
 #define NUMBER_OF_SAMPLES_FLOAT 5.0
-
-struct Sample
-{
-	std::string path;
-	std::string filename;
-	drwav_uint64 total_sample_count;
-	bool loading;
-	vector<float> playBuffer;
-	unsigned int sample_rate;
-	unsigned int channels;
-	bool run = false;
-
-	Sample()
-	{
-		playBuffer.resize(0);
-		total_sample_count = 0;
-		loading = false;
-		filename = "[ empty ]";
-		path = "";
-		sample_rate = 0;
-		channels = 0;
-	}
-
-	void load(std::string path)
-	{
-		this->loading = true;
-
-		unsigned int reported_channels;
-		unsigned int reported_sample_rate;
-		drwav_uint64 reported_total_sample_count;
-		float *pSampleData;
-
-		pSampleData = drwav_open_and_read_file_f32(path.c_str(), &reported_channels, &reported_sample_rate, &reported_total_sample_count);
-
-		if (pSampleData != NULL)
-		{
-			// I'm aware that the "this" pointer isn't necessary here, but I wanted to include
-			// it just to make the code as clear as possible.
-
-			this->channels = reported_channels;
-			this->sample_rate = reported_sample_rate;
-			this->playBuffer.clear();
-
-			for (unsigned int i=0; i < reported_total_sample_count; i = i + this->channels)
-			{
-				this->playBuffer.push_back(pSampleData[i]);
-			}
-
-			drwav_free(pSampleData);
-
-			this->total_sample_count = playBuffer.size();
-			this->loading = false;
-			this->filename = rack::string::filename(path);
-			this->path = path;
-
-			this->run = true;
-		}
-		else
-		{
-			this->loading = false;
-		}
-	};
-};
 
 struct Goblin
 {
@@ -105,7 +40,7 @@ struct Goblin
 		if (sample_position >= this->sample_ptr->total_sample_count) sample_position = sample_position % this->sample_ptr->total_sample_count;
 
         // Return the audio
-		return(this->sample_ptr->playBuffer[sample_position]);
+		return(this->sample_ptr->leftPlayBuffer[sample_position]);
 	}
 
 	void age(float step_amount, float playback_length)
@@ -133,7 +68,7 @@ struct Goblins : Module
 	std::string root_dir;
 	std::string path;
 
-	vector<Goblin> countryside;
+	std::vector<Goblin> countryside;
 	Sample samples[NUMBER_OF_SAMPLES];
 	dsp::SchmittTrigger purge_trigger;
 	dsp::SchmittTrigger purge_button_trigger;
@@ -254,7 +189,7 @@ struct Goblins : Module
 		lights[PURGE_LIGHT].setSmoothBrightness(purge_is_triggered, args.sampleTime);
 
 		// Spawn new goblins
-		if((spawn_rate_counter >= spawn_rate) && (selected_sample->run))
+		if((spawn_rate_counter >= spawn_rate) && (selected_sample->loaded))
 		{
 			Goblin goblin;
 			goblin.start_position = start_position;
@@ -320,7 +255,7 @@ struct GoblinsSampleReadout : TransparentWidget
 	Goblins *module;
 
 	int frame = 0;
-	shared_ptr<Font> font;
+	std::shared_ptr<Font> font;
 
 	GoblinsSampleReadout()
 	{

--- a/src/repeater.cpp
+++ b/src/repeater.cpp
@@ -6,89 +6,25 @@
 
 #include "plugin.hpp"
 #include "osdialog.h"
-#include "dr_wav.h"
-#include <vector>
 #include "cmath"
-
-using namespace std;
+#include "sample.hpp"
 
 #define NUMBER_OF_SAMPLES 5
 #define NUMBER_OF_SAMPLES_FLOAT 5.0
 #define GAIN 5.0
-
-struct sample
-{
-	std::string path;
-	std::string filename;
-	drwav_uint64 total_sample_count;
-	bool loading;
-	vector<float> playBuffer;
-	unsigned int sample_rate;
-	unsigned int channels;
-	bool run = false;
-
-	sample()
-	{
-		playBuffer.resize(0);
-		total_sample_count = 0;
-		loading = false;
-		filename = "[ empty ]";
-		path = "";
-		sample_rate = 0;
-		channels = 0;
-	}
-
-	void load(std::string path)
-	{
-		this->loading = true;
-
-		unsigned int reported_channels;
-		unsigned int reported_sample_rate;
-		drwav_uint64 reported_total_sample_count;
-		float *pSampleData;
-
-		pSampleData = drwav_open_and_read_file_f32(path.c_str(), &reported_channels, &reported_sample_rate, &reported_total_sample_count);
-
-		if (pSampleData != NULL)
-		{
-			// I'm aware that the "this" pointer isn't necessary here, but I wanted to include
-			// it just to make the code as clear as possible.
-
-			this->channels = reported_channels;
-			this->sample_rate = reported_sample_rate;
-			this->playBuffer.clear();
-
-			for (unsigned int i=0; i < reported_total_sample_count; i = i + this->channels)
-			{
-				this->playBuffer.push_back(pSampleData[i]);
-			}
-
-			drwav_free(pSampleData);
-
-			this->total_sample_count = playBuffer.size();
-			this->loading = false;
-			this->filename = rack::string::filename(path);
-			this->path = path;
-		}
-		else
-		{
-			this->loading = false;
-		}
-	};
-};
-
 
 struct Repeater : Module
 {
 	unsigned int selected_sample_slot = 0;
 	float samplePos = 0;
 	int step = 0;
+	bool isPlaying = false;
 	float smooth_ramp = 1;
 	float last_wave_output_voltage = 0;
 	int retrigger;
 	std::string root_dir;
 
-	sample samples[NUMBER_OF_SAMPLES];
+	Sample samples[NUMBER_OF_SAMPLES];
 	dsp::SchmittTrigger playTrigger;
 	dsp::PulseGenerator triggerOutputPulse;
 
@@ -181,7 +117,7 @@ struct Repeater : Module
 			selected_sample_slot = sample_select_input_value;
 		}
 
-		sample *selected_sample = &samples[selected_sample_slot];
+		Sample *selected_sample = &samples[selected_sample_slot];
 
 		if (inputs[TRIG_INPUT].isConnected())
 		{
@@ -200,7 +136,7 @@ struct Repeater : Module
 
 				if(step == 0)
 				{
-					selected_sample->run = true;
+					isPlaying = true;
 					samplePos = selected_sample->total_sample_count * (((inputs[POSITION_INPUT].getVoltage() / 10.0) * params[POSITION_ATTN_KNOB].getValue()) + params[POSITION_KNOB].getValue());
 					smooth_ramp = 0;
 					triggerOutputPulse.trigger(0.01f);
@@ -217,18 +153,18 @@ struct Repeater : Module
 			smooth_ramp = 0;
 		}
 
-		if ((! selected_sample->loading) && (selected_sample->run) && (selected_sample->total_sample_count > 0) && ((abs(floor(samplePos)) < selected_sample->total_sample_count)))
+		if (isPlaying && (! selected_sample->loading) && (selected_sample->loaded) && (selected_sample->total_sample_count > 0) && ((abs(floor(samplePos)) < selected_sample->total_sample_count)))
 		{
 			float wav_output_voltage;
 
 			if (samplePos >= 0)
 			{
-				wav_output_voltage = GAIN  * selected_sample->playBuffer[floor(samplePos)];
+				wav_output_voltage = GAIN  * selected_sample->leftPlayBuffer[floor(samplePos)];
 			}
 			else
 			{
 				// What is this for?  Does it play the sample in reverse?  I think so.
-				wav_output_voltage = GAIN * selected_sample->playBuffer[floor(selected_sample->total_sample_count - 1 + samplePos)];
+				wav_output_voltage = GAIN * selected_sample->leftPlayBuffer[floor(selected_sample->total_sample_count - 1 + samplePos)];
 			}
 
 			if(params[SMOOTH_SWITCH].getValue()  && (smooth_ramp < 1))
@@ -257,7 +193,7 @@ struct Repeater : Module
 		}
 		else
 		{
-			selected_sample->run = false;
+			isPlaying = false;
 			outputs[WAV_OUTPUT].setVoltage(0);
 		}
 
@@ -271,7 +207,7 @@ struct Readout : TransparentWidget
 	Repeater *module;
 
 	int frame = 0;
-	shared_ptr<Font> font;
+	std::shared_ptr<Font> font;
 
 	Readout()
 	{

--- a/src/repeater.cpp
+++ b/src/repeater.cpp
@@ -6,7 +6,6 @@
 
 #include "plugin.hpp"
 #include "osdialog.h"
-#include "cmath"
 #include "sample.hpp"
 
 #define NUMBER_OF_SAMPLES 5

--- a/src/sample.hpp
+++ b/src/sample.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "dr_wav.h"
+
+struct Sample
+{
+	std::string path;
+	std::string filename;
+	drwav_uint64 total_sample_count;
+	bool loading;
+	std::vector<float> leftPlayBuffer;
+	std::vector<float> rightPlayBuffer;
+	unsigned int sample_rate;
+	unsigned int channels;
+	bool loaded = false;
+
+	Sample()
+	{
+		leftPlayBuffer.resize(0);
+		rightPlayBuffer.resize(0);
+		total_sample_count = 0;
+		loading = false;
+		filename = "[ empty ]";
+		path = "";
+		sample_rate = 0;
+		channels = 0;
+	}
+
+	virtual ~Sample() {} 
+
+	virtual void load(std::string path, bool loadAsMono = true)
+	{
+		this->loading = true;
+
+		unsigned int reported_channels;
+		unsigned int reported_sample_rate;
+		drwav_uint64 reported_total_sample_count;
+		float *pSampleData;
+
+		pSampleData = drwav_open_and_read_file_f32(path.c_str(), &reported_channels, &reported_sample_rate, &reported_total_sample_count);
+
+		if (pSampleData != NULL)
+		{
+			// I'm aware that the "this" pointer isn't necessary here, but I wanted to include
+			// it just to make the code as clear as possible.
+
+			this->channels = reported_channels;
+			this->sample_rate = reported_sample_rate;
+			this->leftPlayBuffer.clear();
+			this->rightPlayBuffer.clear();
+
+			if(this->channels > 1 && ! loadAsMono) {
+				for (unsigned int i=0; i < reported_total_sample_count; i = i + this->channels)
+				{
+					this->leftPlayBuffer.push_back(pSampleData[i]);
+					this->rightPlayBuffer.push_back(pSampleData[i+1]);
+				}
+			}
+			else {
+				for (unsigned int i=0; i < reported_total_sample_count; i = i + this->channels)
+				{
+					this->leftPlayBuffer.push_back(pSampleData[i]);
+				}
+			}
+
+			drwav_free(pSampleData);
+
+			this->total_sample_count = leftPlayBuffer.size();
+			this->filename = rack::string::filename(path);
+			this->path = path;
+
+			this->loading = false;
+			this->loaded = true;
+		}
+		else
+		{
+			this->loading = false;
+		}
+	};
+};
+
+

--- a/src/wavbank.cpp
+++ b/src/wavbank.cpp
@@ -6,9 +6,6 @@
 
 #include "plugin.hpp"
 #include "osdialog.h"
-#include <vector>
-#include "cmath"
-#include <memory>
 #include "sample.hpp"
 
 #define GAIN 5.0


### PR DESCRIPTION
This PR implements some new features in wavbank : 

- Stereo output : playback stereo samples. Mono samples just duplicates the left output.
- Loop Switch : when activated, playback restarts when end of buffer is reached. 
- When trig is patched, sample playback won't start automatically when a new sample is selected.

Also, I cleaned up the plugin code a little, mostly by putting the `Sample` struct into its own file, removed some unused "includes" (those are already there by including `plugin.hpp`) , and for consistency, replace  `vector` by `std::vector`, thus removing the need of having the `using namespace std;` statement. 

PS : I didn't update the wavbank panel as I didn't know which font you used. 