### PR TITLE
Digital sequencer reset options

### DIFF
--- a/src/DigitalSequencer/DigitalSequencer.hpp
+++ b/src/DigitalSequencer/DigitalSequencer.hpp
@@ -12,6 +12,7 @@ struct DigitalSequencer : Module
   dsp::SchmittTrigger sequencer_6_button_trigger;
 
   long clock_ignore_on_reset = 0;
+  bool legacy_reset = false;
   bool first_step = true;
   unsigned int tooltip_timer = 0;
 
@@ -442,11 +443,23 @@ struct DigitalSequencer : Module
         gate_sequencers[i].reset();
       }
     }
-    else if(clock_ignore_on_reset == 0)
+
+    //
+    // The legacy reset option in the context menu tells the module to accept
+    // clock signals immedately after resetting.  Reset signals are supposed to
+    // cause clock signals to be ignored for 1 millisecond, however, some older
+    // modules don't do that, so this flag helps with compatibility with older
+    // modules.
+    //
+    if(legacy_reset || clock_ignore_on_reset == 0)
     {
       // Step ALL of the sequencers
       bool global_step_trigger = stepTrigger.process(rescale(inputs[STEP_INPUT].getVoltage(), 0.0f, 10.0f, 0.f, 1.f));
       bool step;
+
+      //
+      // reset_first_step ensures that the first step of the sequence is not skipped
+      // after a reset.  This functionality is disbled in legacy reset mode.
       bool reset_first_step = false;
 
       for(unsigned int i=0; i < NUMBER_OF_SEQUENCERS; i++)
@@ -464,7 +477,7 @@ struct DigitalSequencer : Module
 
         if(step)
         {
-          if(first_step == false)
+          if(legacy_reset || first_step == false)
           {
             voltage_sequencers[i].step();
             gate_sequencers[i].step();

--- a/src/DigitalSequencer/DigitalSequencer.hpp
+++ b/src/DigitalSequencer/DigitalSequencer.hpp
@@ -261,6 +261,9 @@ struct DigitalSequencer : Module
     json_object_set(json_root, "sample_and_hold", sequencer_sh_json_array);
     json_decref(sequencer_sh_json_array);
 
+    // Save Legacy Reset mode
+    json_object_set_new(json_root, "legacy_reset", json_integer(legacy_reset));
+
     return json_root;
   }
 
@@ -372,6 +375,9 @@ struct DigitalSequencer : Module
         this->voltage_sequencers[sequencer_number].sample_and_hold = json_integer_value(sh_json);
       }
     }
+
+    json_t* legacy_reset_json = json_object_get(json_root, "legacy_reset");
+    if (legacy_reset_json) legacy_reset = json_integer_value(legacy_reset_json);
   }
 
 

--- a/src/DigitalSequencer/DigitalSequencerWidget.hpp
+++ b/src/DigitalSequencer/DigitalSequencerWidget.hpp
@@ -194,6 +194,14 @@ struct DigitalSequencerWidget : ModuleWidget
 
   };
 
+  struct LegacyResetOption : MenuItem {
+    DigitalSequencer *module;
+
+    void onAction(const event::Action &e) override {
+      module->legacy_reset ^= true; // flip the value
+    }
+  };
+
   void appendContextMenu(Menu *menu) override
   {
     DigitalSequencer *module = dynamic_cast<DigitalSequencer*>(this->module);
@@ -220,6 +228,11 @@ struct DigitalSequencerWidget : ModuleWidget
       sequencer_items[i]->sequencer_number = i;
       menu->addChild(sequencer_items[i]);
     }
+
+    // Reset behavior
+    LegacyResetOption *legacy_reset_option = createMenuItem<LegacyResetOption>("Legacy Reset", CHECKMARK(module->legacy_reset));
+    legacy_reset_option->module = module;
+    menu->addChild(legacy_reset_option);
   }
 
   void step() override {

--- a/src/DigitalSequencer/DigitalSequencerWidget.hpp
+++ b/src/DigitalSequencer/DigitalSequencerWidget.hpp
@@ -46,12 +46,14 @@ struct DigitalSequencerWidget : ModuleWidget
     addParam(createParamCentered<LEDButton>(mm2px(Vec(button_group_x + (button_spacing * 5.0), button_group_y)), module, DigitalSequencer::SEQUENCER_6_BUTTON));
     addChild(createLightCentered<MediumLight<GreenLight>>(mm2px(Vec(button_group_x + (button_spacing * 5.0), button_group_y)), module, DigitalSequencer::SEQUENCER_6_LIGHT));
 
-    addParam(createParamCentered<Trimpot>(mm2px(Vec(button_group_x, button_group_y + 8.6)), module, DigitalSequencer::SEQUENCER_1_LENGTH_KNOB));
-    addParam(createParamCentered<Trimpot>(mm2px(Vec(button_group_x + (button_spacing * 1.0), button_group_y + 8.6)), module, DigitalSequencer::SEQUENCER_2_LENGTH_KNOB));
-    addParam(createParamCentered<Trimpot>(mm2px(Vec(button_group_x + (button_spacing * 2.0), button_group_y + 8.6)), module, DigitalSequencer::SEQUENCER_3_LENGTH_KNOB));
-    addParam(createParamCentered<Trimpot>(mm2px(Vec(button_group_x + (button_spacing * 3.0), button_group_y + 8.6)), module, DigitalSequencer::SEQUENCER_4_LENGTH_KNOB));
-    addParam(createParamCentered<Trimpot>(mm2px(Vec(button_group_x + (button_spacing * 4.0), button_group_y + 8.6)), module, DigitalSequencer::SEQUENCER_5_LENGTH_KNOB));
-    addParam(createParamCentered<Trimpot>(mm2px(Vec(button_group_x + (button_spacing * 5.0), button_group_y + 8.6)), module, DigitalSequencer::SEQUENCER_6_LENGTH_KNOB));
+    // addParam(createParamCentered<Trimpot>(mm2px(Vec(button_group_x, button_group_y + 8.6)), module, DigitalSequencer::SEQUENCER_1_LENGTH_KNOB));
+
+    auto L1 = createParamCentered<Trimpot>(mm2px(Vec(button_group_x, button_group_y + 8.6)), module, DigitalSequencer::SEQUENCER_1_LENGTH_KNOB); dynamic_cast<Knob*>(L1)->snap = true; addParam(L1);
+    auto L2 = createParamCentered<Trimpot>(mm2px(Vec(button_group_x + (button_spacing * 1.0), button_group_y + 8.6)), module, DigitalSequencer::SEQUENCER_2_LENGTH_KNOB); dynamic_cast<Knob*>(L2)->snap = true; addParam(L2);
+    auto L3 = createParamCentered<Trimpot>(mm2px(Vec(button_group_x + (button_spacing * 2.0), button_group_y + 8.6)), module, DigitalSequencer::SEQUENCER_3_LENGTH_KNOB); dynamic_cast<Knob*>(L3)->snap = true; addParam(L3);
+    auto L4 = createParamCentered<Trimpot>(mm2px(Vec(button_group_x + (button_spacing * 3.0), button_group_y + 8.6)), module, DigitalSequencer::SEQUENCER_4_LENGTH_KNOB); dynamic_cast<Knob*>(L4)->snap = true; addParam(L4);
+    auto L5 = createParamCentered<Trimpot>(mm2px(Vec(button_group_x + (button_spacing * 4.0), button_group_y + 8.6)), module, DigitalSequencer::SEQUENCER_5_LENGTH_KNOB); dynamic_cast<Knob*>(L5)->snap = true; addParam(L5);
+    auto L6 = createParamCentered<Trimpot>(mm2px(Vec(button_group_x + (button_spacing * 5.0), button_group_y + 8.6)), module, DigitalSequencer::SEQUENCER_6_LENGTH_KNOB); dynamic_cast<Knob*>(L6)->snap = true; addParam(L6);
 
     // 6 step inputs
     addInput(createInputCentered<PJ301MPort>(mm2px(Vec(button_group_x, button_group_y + 18.0)), module, DigitalSequencer::SEQUENCER_1_STEP_INPUT));
@@ -190,16 +192,42 @@ struct DigitalSequencerWidget : ModuleWidget
     }
   };
 
-  struct AllSequencersItem : MenuItem {
-
-  };
-
-  struct LegacyResetOption : MenuItem {
+  struct ResetOnNextOption : MenuItem {
     DigitalSequencer *module;
 
     void onAction(const event::Action &e) override {
-      module->legacy_reset ^= true; // flip the value
+      module->legacy_reset = false;
     }
+  };
+
+  struct ResetInstantOption : MenuItem {
+    DigitalSequencer *module;
+
+    void onAction(const event::Action &e) override {
+      module->legacy_reset = true;
+    }
+  };
+
+  struct ResetModeItem : MenuItem {
+    DigitalSequencer *module;
+
+    Menu *createChildMenu() override {
+      Menu *menu = new Menu;
+
+      ResetOnNextOption *reset_on_next = createMenuItem<ResetOnNextOption>("Next clock input.", CHECKMARK(! module->legacy_reset));
+      reset_on_next->module = module;
+      menu->addChild(reset_on_next);
+
+      ResetInstantOption *reset_instant = createMenuItem<ResetInstantOption>("Instant", CHECKMARK(module->legacy_reset));
+      reset_instant->module = module;
+      menu->addChild(reset_instant);
+
+      return menu;
+    }
+  };
+
+  struct AllSequencersItem : MenuItem {
+
   };
 
   void appendContextMenu(Menu *menu) override
@@ -230,9 +258,15 @@ struct DigitalSequencerWidget : ModuleWidget
     }
 
     // Reset behavior
+    /*
     LegacyResetOption *legacy_reset_option = createMenuItem<LegacyResetOption>("Legacy Reset", CHECKMARK(module->legacy_reset));
     legacy_reset_option->module = module;
     menu->addChild(legacy_reset_option);
+    */
+
+    ResetModeItem *reset_mode_item = createMenuItem<ResetModeItem>("Reset Mode", RIGHT_ARROW);
+    reset_mode_item->module = module;
+    menu->addChild(reset_mode_item);
   }
 
   void step() override {


### PR DESCRIPTION
Added reset modes for backwards compatibility to older modules.  Also adjusted length inputs so that they snap, which helps in the tooltip display.