### PR TITLE
DSPX upgrades

### DIFF
--- a/src/DigitalSequencerXP/DigitalSequencerXP.hpp
+++ b/src/DigitalSequencerXP/DigitalSequencerXP.hpp
@@ -549,7 +549,7 @@ struct DigitalSequencerXP : Module
       if(i < (unsigned int) inputs[POLY_LENGTH_INPUT].getChannels()) // If there's an input controlling this sequencer
       {
         float length_input = inputs[POLY_LENGTH_INPUT].getVoltage(i);
-        int length = ((length_input / 10.0) * 31) + 1;
+        int length = ((length_input / 10.0) * 32) + 1;
         length = clamp(length, 1.0, 32.0);
 
         voltage_sequencers[i].setLength((int) length);

--- a/src/DigitalSequencerXP/DigitalSequencerXPWidget.hpp
+++ b/src/DigitalSequencerXP/DigitalSequencerXPWidget.hpp
@@ -282,6 +282,19 @@ struct DigitalSequencerXPWidget : ModuleWidget
         }
       }
 
+      // Switch between seuences using the number keys 1-6
+      if (e.key >= GLFW_KEY_1 && e.key <= GLFW_KEY_8) // quick-select
+      {
+        if(e.action == GLFW_PRESS)
+        {
+          unsigned int sequencer_number = e.key - 49;
+          if ((e.mods & RACK_MOD_MASK) == GLFW_MOD_SHIFT) sequencer_number += 8;
+          sequencer_number = clamp(sequencer_number,0,NUMBER_OF_SEQUENCERS-1);
+          module->selected_sequencer_index = sequencer_number;
+          e.consume(this);
+        }
+      }
+
       ModuleWidget::onHoverKey(e);
 
   }


### PR DESCRIPTION
- Restored number keys 1-8 (and shift+ 1-8) for quickly selecting sequencers
- Improved sequence length CV input to more easily reach 32 steps
- Added easy way to set sequence length using CTRL+drag
- Fixed unlikely edge case where shift or control keys would seem pressed when they weren't