### PR TITLE
Fix ambiguity of clamp use

### DIFF
--- a/src/DigitalSequencerXP/DigitalSequencerXP.hpp
+++ b/src/DigitalSequencerXP/DigitalSequencerXP.hpp
@@ -582,7 +582,7 @@ struct DigitalSequencerXP : Module
       {
         float length_input = inputs[POLY_LENGTH_INPUT].getVoltage(i);
         int length = ((length_input / 10.0) * 32) + 1;
-        length = clamp(length, 1.0, 32.0);
+        length = clamp(length, 1, 32);
 
         voltage_sequencers[i].setLength((int) length);
         gate_sequencers[i].setLength((int) length);


### PR DESCRIPTION
The clamp function from Rack has an `int` and `float` version.
Which one was being called here was unclear because `length` is `int` but the other values are `double`.
This can generate a compiler warning in some conditions.

```
In file included from voxglitch/src/DigitalSequencerXP.cpp:26:0:
voxglitch/src/DigitalSequencerXP/DigitalSequencerXP.hpp: In member function 'void DigitalSequencerXP::set_sequencer_lengths()':
voxglitch/src/DigitalSequencerXP/DigitalSequencerXP.hpp:585:41: error: call of overloaded 'clamp(int&, float, float)' is ambiguous
         length = clamp(length, 1.0, 32.0);
                                         ^
```

We can simply make all arguments an integer, which fixes the ambiguity.