### PR TITLE
Cardinal specific changes

### DIFF
--- a/src/Autobreak/AutobreakLoadSample.hpp
+++ b/src/Autobreak/AutobreakLoadSample.hpp
@@ -6,8 +6,20 @@ struct AutobreakLoadSample : MenuItem
 	void onAction(const event::Action &e) override
 	{
 		const std::string dir = module->root_dir.empty() ? "" : module->root_dir;
+#ifdef USING_CARDINAL_NOT_RACK
+		Autobreak *module = this->module;
+		unsigned int sample_number = this->sample_number;
+		async_dialog_filebrowser(false, dir.c_str(), text.c_str(), [module, sample_number](char* path) {
+			pathSelected(module, sample_number, path);
+		});
+#else
 		char *path = osdialog_file(OSDIALOG_OPEN, dir.c_str(), NULL, osdialog_filters_parse("Wav:wav"));
+		pathSelected(module, sample_number, path);
+#endif
+	}
 
+	static void pathSelected(Autobreak *module, unsigned int sample_number, char *path)
+	{
 		if (path)
 		{
 			module->samples[sample_number].load(path);

--- a/src/Ghosts/LoadSample.hpp
+++ b/src/Ghosts/LoadSample.hpp
@@ -5,9 +5,20 @@ struct GhostsLoadSample : MenuItem
 	void onAction(const event::Action &e) override
 	{
 		const std::string dir = "";
+#ifdef USING_CARDINAL_NOT_RACK
+		Ghosts *module = this->module;
+		async_dialog_filebrowser(false, dir.c_str(), text.c_str(), [module](char* path) {
+			pathSelected(module, path);
+		});
+#else
 		char *path = osdialog_file(OSDIALOG_OPEN, dir.c_str(), NULL, osdialog_filters_parse("Wav:wav"));
+		pathSelected(module, path);
+#endif
+	}
 
-		if(path)
+	static void pathSelected(Ghosts *module, char *path)
+	{
+		if (path)
 		{
 			module->sample.load(path);
 			module->root_dir = std::string(path);

--- a/src/Goblins/GoblinsLoadSample.hpp
+++ b/src/Goblins/GoblinsLoadSample.hpp
@@ -6,8 +6,20 @@ struct GoblinsLoadSample : MenuItem
 	void onAction(const event::Action &e) override
 	{
 		const std::string dir = module->root_dir.empty() ? "" : module->root_dir;
+#ifdef USING_CARDINAL_NOT_RACK
+		Goblins *module = this->module;
+		unsigned int sample_number = this->sample_number;
+		async_dialog_filebrowser(false, dir.c_str(), text.c_str(), [module, sample_number](char* path) {
+			pathSelected(module, sample_number, path);
+		});
+#else
 		char *path = osdialog_file(OSDIALOG_OPEN, dir.c_str(), NULL, osdialog_filters_parse("Wav:wav"));
+		pathSelected(module, sample_number, path);
+#endif
+	}
 
+	static void pathSelected(Goblins *module, unsigned int sample_number, char *path)
+	{
 		if (path)
 		{
 			module->samples[sample_number].load(path);

--- a/src/GrainEngine/GrainEngineLoadSample.hpp
+++ b/src/GrainEngine/GrainEngineLoadSample.hpp
@@ -5,9 +5,20 @@ struct GrainEngineLoadSample : MenuItem
 	void onAction(const event::Action &e) override
 	{
 		const std::string dir = "";
+#ifdef USING_CARDINAL_NOT_RACK
+		GrainEngine *module = this->module;
+		async_dialog_filebrowser(false, dir.c_str(), text.c_str(), [module](char* path) {
+			pathSelected(module, path);
+		});
+#else
 		char *path = osdialog_file(OSDIALOG_OPEN, dir.c_str(), NULL, osdialog_filters_parse("Wav:wav"));
+		pathSelected(module, path);
+#endif
+	}
 
-		if(path)
+	static void pathSelected(GrainEngine *module, char *path)
+	{
+		if (path)
 		{
 			module->sample.load(path);
 			module->root_dir = std::string(path);

--- a/src/GrainEngineMK2/GrainEngineMK2LoadSample.hpp
+++ b/src/GrainEngineMK2/GrainEngineMK2LoadSample.hpp
@@ -1,17 +1,29 @@
 struct GrainEngineMK2LoadSample : MenuItem
 {
 	GrainEngineMK2 *module;
-  unsigned int sample_number = 0;
+	unsigned int sample_number = 0;
 
 	void onAction(const event::Action &e) override
 	{
 		const std::string dir = module->root_dir.empty() ? "" : module->root_dir;
+#ifdef USING_CARDINAL_NOT_RACK
+		GrainEngineMK2 *module = this->module;
+		unsigned int sample_number = this->sample_number;
+		async_dialog_filebrowser(false, dir.c_str(), text.c_str(), [module, sample_number](char* path) {
+			pathSelected(module, sample_number, path);
+		});
+#else
 		char *path = osdialog_file(OSDIALOG_OPEN, dir.c_str(), NULL, osdialog_filters_parse("Wav:wav"));
+		pathSelected(module, sample_number, path);
+#endif
+	}
 
-		if(path)
+	static void pathSelected(GrainEngineMK2 *module, unsigned int sample_number, char *path)
+	{
+		if (path)
 		{
-      module->load_queue.queue_sample_for_loading(std::string(path), sample_number);
-      module->fade_out_on_load.trigger();
+			module->load_queue.queue_sample_for_loading(std::string(path), sample_number);
+			module->fade_out_on_load.trigger();
 
 			// module->samples[sample_number]->load(path);
 			// module->root_dir = std::string(path);

--- a/src/Looper/LooperLoadSample.hpp
+++ b/src/Looper/LooperLoadSample.hpp
@@ -5,16 +5,27 @@ struct LooperLoadSample : MenuItem
 	void onAction(const event::Action &e) override
 	{
 		const std::string dir = module->root_dir.empty() ? "" : module->root_dir;
+#ifdef USING_CARDINAL_NOT_RACK
+		Looper *module = this->module;
+		async_dialog_filebrowser(false, dir.c_str(), module->loaded_filename.c_str(), [module](char* path) {
+			pathSelected(module, path);
+		});
+#else
 		char *path = osdialog_file(OSDIALOG_OPEN, dir.c_str(), NULL, osdialog_filters_parse("Wav:wav"));
+		pathSelected(module, path);
+#endif
+	}
 
+	static void pathSelected(Looper *module, char *path)
+	{
 		if (path)
 		{
-      module->root_dir = std::string(path);
+			module->root_dir = std::string(path);
 			module->sample_player.loadSample(std::string(path));
-      module->loaded_filename = module->sample_player.getFilename();
+			module->loaded_filename = module->sample_player.getFilename();
 			free(path);
 
-      // module->sample_player.loadSample(std::string(path));
+			// module->sample_player.loadSample(std::string(path));
 		}
 	}
 };

--- a/src/Looper/LooperWaveformDisplay.hpp
+++ b/src/Looper/LooperWaveformDisplay.hpp
@@ -47,21 +47,31 @@ struct LooperWaveformDisplay : TransparentWidget
         e.consume(this);
 
         // Open dialog box and prompt user for sample
-    		const std::string dir = module->root_dir.empty() ? "" : module->root_dir;
-    		char *path = osdialog_file(OSDIALOG_OPEN, dir.c_str(), NULL, osdialog_filters_parse("Wav:wav"));
-
-    		if (path)
-    		{
-          module->root_dir = std::string(path);
-    			module->sample_player.loadSample(std::string(path));
-          module->loaded_filename = module->sample_player.getFilename();
-    			free(path);
-
-          // Redundant and dangerous code
-          // module->sample_player.loadSample(std::string(path));
-    		}
-
+        const std::string dir = module->root_dir.empty() ? "" : module->root_dir;
+#ifdef USING_CARDINAL_NOT_RACK
+        Looper *module = this->module;
+        async_dialog_filebrowser(false, dir.c_str(), module->loaded_filename.c_str(), [module](char* path) {
+            pathSelected(module, path);
+        });
+#else
+        char *path = osdialog_file(OSDIALOG_OPEN, dir.c_str(), NULL, osdialog_filters_parse("Wav:wav"));
+        pathSelected(module, path);
+#endif
       }
+    }
+  }
+
+  static void pathSelected(Looper *module, char *path)
+  {
+    if (path)
+    {
+      module->root_dir = std::string(path);
+      module->sample_player.loadSample(std::string(path));
+      module->loaded_filename = module->sample_player.getFilename();
+      free(path);
+
+      // Redundant and dangerous code
+      // module->sample_player.loadSample(std::string(path));
     }
   }
 

--- a/src/Repeater/MenuItemLoadSample.hpp
+++ b/src/Repeater/MenuItemLoadSample.hpp
@@ -6,8 +6,20 @@ struct MenuItemLoadSample : MenuItem
 	void onAction(const event::Action &e) override
 	{
 		const std::string dir = module->root_dir.empty() ? "" : module->root_dir;
+#ifdef USING_CARDINAL_NOT_RACK
+		Repeater *module = this->module;
+		unsigned int sample_number = this->sample_number;
+		async_dialog_filebrowser(false, dir.c_str(), text.c_str(), [module, sample_number](char* path) {
+			pathSelected(module, sample_number, path);
+		});
+#else
 		char *path = osdialog_file(OSDIALOG_OPEN, dir.c_str(), NULL, osdialog_filters_parse("Wav:wav"));
+		pathSelected(module, sample_number, path);
+#endif
+	}
 
+	static void pathSelected(Repeater *module, unsigned int sample_number, char *path)
+	{
 		if (path)
 		{
 			module->any_sample_has_been_loaded = true;

--- a/src/SamplerX8/SamplerX8LoadFolder.hpp
+++ b/src/SamplerX8/SamplerX8LoadFolder.hpp
@@ -2,40 +2,53 @@ struct SamplerX8LoadFolder : MenuItem
 {
 	SamplerX8 *module;
 	unsigned int sample_number = 0;
-  std::string root_dir;
+	std::string root_dir;
 
 	void onAction(const event::Action &e) override
 	{
 		const std::string dir = root_dir.empty() ? "" : root_dir;
-    char *path = osdialog_file(OSDIALOG_OPEN_DIR, dir.c_str(), NULL, NULL);
+#ifdef USING_CARDINAL_NOT_RACK
+		SamplerX8 *module = this->module;
+		unsigned int sample_number = this->sample_number;
+		async_dialog_filebrowser(false, dir.c_str(), text.c_str(), [module, sample_number](char *path) {
+			if (path) {
+				if (char *rpath = strrchr(path, CARDINAL_OS_SEP))
+					*rpath = '\0';
+				pathSelected(module, sample_number, path);
+			}
+		});
+#else
+		char *path = osdialog_file(OSDIALOG_OPEN_DIR, dir.c_str(), NULL, NULL);
+		pathSelected(module, sample_number, path);
+#endif
+	}
 
+	static void pathSelected(SamplerX8 *module, unsigned int sample_number, char *path)
+	{
 		if (path)
 		{
-      root_dir = std::string(path);
+			std::vector<std::string> dirList = system::getEntries(path);
+			unsigned int i = 0;
 
-      std::vector<std::string> dirList = system::getEntries(path);
+			for (auto entry : dirList)
+			{
+				if (
+					// Something happened in Rack 2 where the extension started to include
+					// the ".", so I decided to check for both versions, just in case.
+					(rack::string::lowercase(system::getExtension(entry)) == "wav") ||
+					(rack::string::lowercase(system::getExtension(entry)) == ".wav")
+				   )
+				{
+					if (i < 8)
+					{
+						module->sample_players[i].loadSample(std::string(entry));
+						module->loaded_filenames[i] = module->sample_players[i].getFilename();
+						i++;
+					}
+				}
+			}
 
-      unsigned int i = 0;
-
-  		for (auto entry : dirList)
-  		{
-  			if (
-          // Something happened in Rack 2 where the extension started to include
-          // the ".", so I decided to check for both versions, just in case.
-          (rack::string::lowercase(system::getExtension(entry)) == "wav") ||
-          (rack::string::lowercase(system::getExtension(entry)) == ".wav")
-        )
-  			{
-          if(i < 8)
-          {
-            module->sample_players[i].loadSample(std::string(entry));
-            module->loaded_filenames[i] = module->sample_players[i].getFilename();
-            i++;
-          }
-  			}
-  		}
+			free(path);
 		}
-
-    free(path);
 	}
 };

--- a/src/SamplerX8/SamplerX8LoadSample.hpp
+++ b/src/SamplerX8/SamplerX8LoadSample.hpp
@@ -2,18 +2,29 @@ struct SamplerX8LoadSample : MenuItem
 {
 	SamplerX8 *module;
 	unsigned int sample_number = 0;
-  std::string root_dir;
+	std::string root_dir;
 
 	void onAction(const event::Action &e) override
 	{
 		const std::string dir = root_dir.empty() ? "" : root_dir;
+#ifdef USING_CARDINAL_NOT_RACK
+		SamplerX8 *module = this->module;
+		unsigned int sample_number = this->sample_number;
+		async_dialog_filebrowser(false, dir.c_str(), text.c_str(), [module, sample_number](char* path) {
+			pathSelected(module, sample_number, path);
+		});
+#else
 		char *path = osdialog_file(OSDIALOG_OPEN, dir.c_str(), NULL, osdialog_filters_parse("Wav:wav"));
+		pathSelected(module, sample_number, path);
+#endif
+	}
 
+	static void pathSelected(SamplerX8 *module, unsigned int sample_number, char *path)
+	{
 		if (path)
 		{
-      root_dir = std::string(path);
 			module->sample_players[sample_number].loadSample(std::string(path));
-      module->loaded_filenames[sample_number] = module->sample_players[sample_number].getFilename();
+			module->loaded_filenames[sample_number] = module->sample_players[sample_number].getFilename();
 			free(path);
 		}
 	}

--- a/src/WavBank/MenuItemLoadBank.hpp
+++ b/src/WavBank/MenuItemLoadBank.hpp
@@ -5,8 +5,23 @@ struct MenuItemLoadBank : MenuItem
 	void onAction(const event::Action &e) override
 	{
 		const std::string dir = wav_bank_module->rootDir;
+#ifdef USING_CARDINAL_NOT_RACK
+		WavBank *wav_bank_module = this->wav_bank_module;
+		async_dialog_filebrowser(false, dir.c_str(), text.c_str(), [wav_bank_module](char* path) {
+			if (path) {
+				if (char *rpath = strrchr(path, CARDINAL_OS_SEP))
+					*rpath = '\0';
+				pathSelected(wav_bank_module, path);
+			}
+		});
+#else
 		char *path = osdialog_file(OSDIALOG_OPEN_DIR, dir.c_str(), NULL, NULL);
+		pathSelected(wav_bank_module, path);
+#endif
+	}
 
+	static void pathSelected(WavBank *wav_bank_module, char *path)
+	{
 		if (path)
 		{
 			wav_bank_module->load_samples_from_path(path);

--- a/src/WavBankMC/MenuItemLoadBankMC.hpp
+++ b/src/WavBankMC/MenuItemLoadBankMC.hpp
@@ -4,17 +4,30 @@ struct MenuItemLoadBankMC : MenuItem
 
 	void onAction(const event::Action &e) override
 	{
-
 		const std::string dir = wav_bank_mc_module->rootDir;
+#ifdef USING_CARDINAL_NOT_RACK
+		WavBankMC *wav_bank_mc_module = this->wav_bank_mc_module;
+		async_dialog_filebrowser(false, dir.c_str(), text.c_str(), [wav_bank_mc_module](char* path) {
+			if (path) {
+				if (char *rpath = strrchr(path, CARDINAL_OS_SEP))
+					*rpath = '\0';
+				pathSelected(wav_bank_mc_module, path);
+			}
+		});
+#else
 		char *path = osdialog_file(OSDIALOG_OPEN_DIR, dir.c_str(), NULL, NULL);
+		pathSelected(wav_bank_mc_module, path);
+#endif
+	}
 
+	static void pathSelected(WavBankMC *wav_bank_mc_module, char *path)
+	{
 		if (path)
 		{
 			wav_bank_mc_module->load_samples_from_path(path);
 			wav_bank_mc_module->path = path;
-      wav_bank_mc_module->selected_sample_slot = 0;
+			wav_bank_mc_module->selected_sample_slot = 0;
+			free(path);
 		}
-
-    free(path);
 	}
 };


### PR DESCRIPTION
Hi there.
Here is a set of changes to make voxglitch play nice with [Cardinal](https://github.com/DISTRHO/Cardinal).
(just a little opensource audio plugin based on Rack)

These changes are required due to Cardinal not making use of `osdialog`, as it blocks the host event loop which IMO is quite the nasty thing to do as a plugin. So Cardinal has specific APIs for async dialogs, not interfering with host state.

I tried to make the changes as non-intrusive as possible.
Some files had issues with spaces vs tabs, I cleared them a bit around the changes I made, so they look nicely aligned now.
There should be no functional changes for the regular Rack / non-Cardinal builds.

Thanks for the great plugins!
