### PR TITLE
Add linear interpolation to 3 more modules

### DIFF
--- a/src/Autobreak/Autobreak.hpp
+++ b/src/Autobreak/Autobreak.hpp
@@ -1,4 +1,4 @@
-struct Autobreak : Module
+struct Autobreak : VoxglitchSamplerModule
 {
   unsigned int selected_sample_slot = 0;
 

--- a/src/Autobreak/AutobreakWidget.hpp
+++ b/src/Autobreak/AutobreakWidget.hpp
@@ -1,4 +1,4 @@
-struct AutobreakWidget : ModuleWidget
+struct AutobreakWidget : VoxglitchSamplerModuleWidget
 {
 	AutobreakWidget(Autobreak* module)
 	{
@@ -66,5 +66,10 @@ struct AutobreakWidget : ModuleWidget
 			menu_item_load_sample->module = module;
 			menu->addChild(menu_item_load_sample);
 		}
+
+    menu->addChild(new MenuEntry); // For spacing only
+    SampleInterpolationMenuItem *sample_interpolation_menu_item = createMenuItem<SampleInterpolationMenuItem>("Interpolation", RIGHT_ARROW);
+    sample_interpolation_menu_item->module = module;
+    menu->addChild(sample_interpolation_menu_item);    
 	}
 };

--- a/src/Repeater/Repeater.hpp
+++ b/src/Repeater/Repeater.hpp
@@ -1,4 +1,4 @@
-struct Repeater : Module
+struct Repeater : VoxglitchSamplerModule
 {
 	unsigned int selected_sample_slot = 0;
 	double samplePos = 0;

--- a/src/Repeater/RepeaterWidget.hpp
+++ b/src/Repeater/RepeaterWidget.hpp
@@ -1,4 +1,4 @@
-struct RepeaterWidget : ModuleWidget
+struct RepeaterWidget : VoxglitchSamplerModuleWidget
 {
 	RepeaterWidget(Repeater* module)
 	{
@@ -93,6 +93,11 @@ struct RepeaterWidget : ModuleWidget
 		retrigger_menu_item->rightText = CHECKMARK(module->retrigger == 1);
 		retrigger_menu_item->module = module;
 		menu->addChild(retrigger_menu_item);
+
+    // Sample interpolation settings
+    SampleInterpolationMenuItem *sample_interpolation_menu_item = createMenuItem<SampleInterpolationMenuItem>("Interpolation", RIGHT_ARROW);
+    sample_interpolation_menu_item->module = module;
+    menu->addChild(sample_interpolation_menu_item);
 	}
 
 };

--- a/src/SamplerX8.cpp
+++ b/src/SamplerX8.cpp
@@ -5,6 +5,8 @@
 #include "plugin.hpp"
 #include "osdialog.h"
 #include "Common/sample.hpp"
+#include "Common/VoxglitchSamplerModule.hpp"
+#include "Common/VoxglitchSamplerModuleWidget.hpp"
 #include "Common/submodules.hpp"
 
 #include "SamplerX8/defines.h"

--- a/src/SamplerX8/SamplerX8.hpp
+++ b/src/SamplerX8/SamplerX8.hpp
@@ -1,4 +1,4 @@
-struct SamplerX8 : Module
+struct SamplerX8 : VoxglitchSamplerModule
 {
 	std::string loaded_filenames[NUMBER_OF_SAMPLES] = {""};
   std::vector<SamplePlayer> sample_players;

--- a/src/SamplerX8/SamplerX8Widget.hpp
+++ b/src/SamplerX8/SamplerX8Widget.hpp
@@ -1,4 +1,4 @@
-struct SamplerX8Widget : ModuleWidget
+struct SamplerX8Widget : VoxglitchSamplerModuleWidget
 {
   SamplerX8Widget(SamplerX8* module)
   {
@@ -123,5 +123,10 @@ struct SamplerX8Widget : ModuleWidget
     menu_item_load_folder->text = "Load first 8 WAV files from a folder";
     menu_item_load_folder->module = module;
     menu->addChild(menu_item_load_folder);
+
+    menu->addChild(new MenuEntry); // For spacing only
+    SampleInterpolationMenuItem *sample_interpolation_menu_item = createMenuItem<SampleInterpolationMenuItem>("Interpolation", RIGHT_ARROW);
+    sample_interpolation_menu_item->module = module;
+    menu->addChild(sample_interpolation_menu_item);
   }
 };

--- a/src/WavBank/WavBank.hpp
+++ b/src/WavBank/WavBank.hpp
@@ -1,4 +1,4 @@
-struct WavBank : Module
+struct WavBank : VoxglitchSamplerModule
 {
 	unsigned int selected_sample_slot = 0;
 	double samplePos = 0;

--- a/src/WavBank/WavBankWidget.hpp
+++ b/src/WavBank/WavBankWidget.hpp
@@ -1,4 +1,4 @@
-struct WavBankWidget : ModuleWidget
+struct WavBankWidget : VoxglitchSamplerModuleWidget
 {
 	WavBankWidget(WavBank* module)
 	{
@@ -86,6 +86,12 @@ struct WavBankWidget : ModuleWidget
 		menu_item_load_bank->text = "Select Directory Containing WAV Files";
 		menu_item_load_bank->wav_bank_module = module;
 		menu->addChild(menu_item_load_bank);
+
+    // Sample interpolation settings
+    menu->addChild(new MenuEntry); // For spacing only
+    SampleInterpolationMenuItem *sample_interpolation_menu_item = createMenuItem<SampleInterpolationMenuItem>("Interpolation", RIGHT_ARROW);
+    sample_interpolation_menu_item->module = module;
+    menu->addChild(sample_interpolation_menu_item);
 	}
 
 };

--- a/src/autobreak.cpp
+++ b/src/autobreak.cpp
@@ -7,6 +7,8 @@
 #include "plugin.hpp"
 #include "osdialog.h"
 #include "Common/sample.hpp"
+#include "Common/VoxglitchSamplerModule.hpp"
+#include "Common/VoxglitchSamplerModuleWidget.hpp"
 #include "Common/submodules.hpp"
 #include <fstream>
 

--- a/src/repeater.cpp
+++ b/src/repeater.cpp
@@ -7,6 +7,8 @@
 #include "plugin.hpp"
 #include "osdialog.h"
 #include "Common/sample.hpp"
+#include "Common/VoxglitchSamplerModule.hpp"
+#include "Common/VoxglitchSamplerModuleWidget.hpp"
 #include "Common/submodules.hpp"
 
 #include "Repeater/defines.h"

--- a/src/wavbank.cpp
+++ b/src/wavbank.cpp
@@ -7,6 +7,8 @@
 #include "plugin.hpp"
 #include "osdialog.h"
 #include "Common/sample.hpp"
+#include "Common/VoxglitchSamplerModule.hpp"
+#include "Common/VoxglitchSamplerModuleWidget.hpp"
 
 #include "WavBank/defines.h"
 #include "WavBank/WavBank.hpp"


### PR DESCRIPTION
Upgraded Autobreak Repeater, SamplerX8, and WavBank to support linear interpolation, which is enabled by default