### PR TITLE
Fixed reset issue in reference to start range

### DIFF
--- a/src/GrooveBox/Track.hpp
+++ b/src/GrooveBox/Track.hpp
@@ -173,7 +173,7 @@ struct Track
 
   void reset()
   {
-    playback_position = 0;
+    playback_position = range_start;
     ratchet_counter = 0;
     fading_out = false;
   }


### PR DESCRIPTION
Fixed issue where reset would always start at step #1, even if the starting range was greater than 1.