### PR TITLE
Fixed double-click on loop parameter knob

### DIFF
--- a/src/GrooveBox/GrooveBoxWidget.hpp
+++ b/src/GrooveBox/GrooveBoxWidget.hpp
@@ -103,6 +103,7 @@ struct TrimpotMedium : SVGKnob {
       case FUNCTION_OFFSET: module->params[parameter_index].setValue(default_offset); break;
       case FUNCTION_PROBABILITY: module->params[parameter_index].setValue(default_probability); break;
       case FUNCTION_REVERSE: module->params[parameter_index].setValue(default_reverse); break;
+      case FUNCTION_LOOP: module->params[parameter_index].setValue(default_loop); break;
     }
   }
 };


### PR DESCRIPTION
Double clicking on the parameter knob when in loop knob did nothing.  The intended behavior is to reset the loop value to 0 at that knob position.  This issue has been fixed.