### PR TITLE
Groovebox - added attack and release parameter locks

### DIFF
--- a/res/groove_box_front_panel.svg
+++ b/res/groove_box_front_panel.svg
@@ -18,6 +18,12 @@
   <defs
      id="defs2">
     <rect
+       x="-101.11627"
+       y="495.3283"
+       width="95.105863"
+       height="34.648233"
+       id="rect7880" />
+    <rect
        x="671.75141"
        y="56.214986"
        width="70.357121"
@@ -209,6 +215,12 @@
        width="70.357124"
        height="39.951553"
        id="rect7665-8" />
+    <rect
+       x="-101.11627"
+       y="495.32831"
+       width="95.105865"
+       height="34.648232"
+       id="rect7880-5" />
   </defs>
   <sodipodi:namedview
      inkscape:guide-bbox="true"
@@ -222,9 +234,9 @@
      inkscape:document-rotation="0"
      inkscape:current-layer="layer1"
      inkscape:document-units="mm"
-     inkscape:cy="216.02112"
-     inkscape:cx="414.71813"
-     inkscape:zoom="2.8284271"
+     inkscape:cy="485.25"
+     inkscape:cx="321.5"
+     inkscape:zoom="4"
      inkscape:pageshadow="2"
      inkscape:pageopacity="1"
      borderopacity="1.0"
@@ -470,6 +482,13 @@
        position="163.79613,116.33924"
        orientation="0,-1"
        id="guide34328" />
+    <sodipodi:guide
+       position="17.044855,15.803001"
+       orientation="0,1"
+       id="guide2450"
+       inkscape:label="r1"
+       inkscape:locked="false"
+       inkscape:color="rgb(248,228,92)" />
   </sodipodi:namedview>
   <metadata
      id="metadata5">
@@ -520,13 +539,13 @@
        style="font-size:16px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect5909-1)"><tspan
          x="514.5"
          y="140.06433"
-         id="tspan2756">
+         id="tspan17681">
 </tspan><tspan
          x="514.5"
          y="174.56433"
-         id="tspan2760"><tspan
+         id="tspan17685"><tspan
            dx="0 8.6399841 8.6399841 8.6399841 8.6399841 8.6399841"
-           id="tspan2758">CSnare</tspan></tspan></text>
+           id="tspan17683">CSnare</tspan></tspan></text>
     <text
        xml:space="preserve"
        transform="matrix(0.26458333,0,0,0.26458333,26.405231,1.7443286)"
@@ -534,9 +553,9 @@
        style="font-size:16px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect26191-3)"><tspan
          x="81.669922"
          y="121.69128"
-         id="tspan2764"><tspan
+         id="tspan17689"><tspan
            dx="0 8.6399841 8.6399841 8.6399841 8.6399841 8.6399841 8.6399841 8.6399841 8.6399841 8.6399841 8.6399841 8.6399841 8.6399841"
-           id="tspan2762">Global Memory</tspan></tspan></text>
+           id="tspan17687">Global Memory</tspan></tspan></text>
     <rect
        style="fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke-width:0.315795;stroke-linejoin:round"
        id="rect1762"
@@ -603,281 +622,367 @@
          style="fill:#ffffff;fill-opacity:0.677596" />
     </g>
     <rect
-       style="fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0593534;stroke-linejoin:round;stroke-opacity:1"
+       style="fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0461193;stroke-linejoin:round;stroke-opacity:1"
        id="rect1762-9-4-1-2"
-       width="22.98173"
-       height="10.211159"
-       x="6.4235821"
-       y="113.18124" />
+       width="21.95388"
+       height="6.4538808"
+       x="6.4195518"
+       y="109.47049" />
     <g
        aria-label="VOLUME"
-       transform="matrix(0.26458333,0,0,0.26458333,-3.7049444,0.50239353)"
+       transform="matrix(0.26458333,0,0,0.26458333,-3.7049444,-5.0870232)"
        id="text32150"
-       style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect32152);fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1">
+       style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect32152);fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1">
       <path
          d="m 61.171173,440.50282 h 1.17333 l 1.599996,8.15998 1.719996,-8.15998 h 1.146664 l -2.093328,9.33331 h -1.586663 z"
-         style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect32152);fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+         style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect32152);fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1"
          id="path69130" />
       <path
          d="m 73.891128,447.56947 q 0,1.13333 -0.626665,1.70666 -0.613332,0.56 -1.773329,0.56 h -0.533332 q -1.159997,0 -1.786662,-0.56 -0.613332,-0.57333 -0.613332,-1.70666 v -4.79999 q 0,-1.13333 0.613332,-1.69333 0.626665,-0.57333 1.786662,-0.57333 h 0.533332 q 1.159997,0 1.773329,0.57333 0.626665,0.56 0.626665,1.69333 z m -1.159997,-5.05332 q 0,-0.41333 -0.306666,-0.70667 -0.306666,-0.29333 -0.799998,-0.29333 h -0.799998 q -0.493332,0 -0.799998,0.29333 -0.306666,0.29334 -0.306666,0.70667 v 5.30665 q 0,0.41333 0.306666,0.70667 0.306666,0.29333 0.799998,0.29333 h 0.799998 q 0.493332,0 0.799998,-0.29333 0.306666,-0.29334 0.306666,-0.70667 z"
-         style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect32152);fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+         style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect32152);fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1"
          id="path69132" />
       <path
          d="m 77.517772,440.50282 v 8.31998 h 2.973326 v 1.01333 h -4.133323 v -9.33331 z"
-         style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect32152);fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+         style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect32152);fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1"
          id="path69134" />
       <path
          d="m 88.1844,447.56947 q 0,1.13333 -0.626665,1.70666 -0.613332,0.56 -1.773329,0.56 h -0.333333 q -1.159997,0 -1.786662,-0.56 -0.613332,-0.57333 -0.613332,-1.70666 v -7.06665 h 1.159997 v 7.31998 q 0,0.41333 0.306666,0.70667 0.306666,0.29333 0.799998,0.29333 h 0.599999 q 0.493332,0 0.799998,-0.29333 0.306666,-0.29334 0.306666,-0.70667 v -7.31998 H 88.1844 Z"
-         style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect32152);fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+         style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect32152);fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1"
          id="path69136" />
       <path
          d="m 93.357706,446.7028 h -1.106663 l -1.306664,-5.23998 v 8.37331 h -1.013331 v -9.33331 h 1.853329 l 1.066664,4.77332 1.079997,-4.77332 h 1.799996 v 9.33331 h -1.039998 v -8.37331 z"
-         style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect32152);fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+         style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect32152);fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1"
          id="path69138" />
       <path
          d="m 102.251,440.50282 v 0.97333 h -3.293321 v 3.05333 h 2.959991 v 0.97333 h -2.959991 v 3.35999 H 102.251 v 0.97333 h -4.453318 v -9.33331 z"
-         style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect32152);fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+         style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect32152);fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1"
          id="path69140" />
     </g>
     <rect
-       style="fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0593534;stroke-linejoin:round;stroke-opacity:1"
+       style="fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0461165;stroke-linejoin:round;stroke-opacity:1"
        id="rect1762-9-4-1-2-8"
-       width="22.98173"
-       height="10.211159"
-       x="33.236141"
-       y="113.18124" />
+       width="21.953409"
+       height="6.4532404"
+       x="33.2295"
+       y="109.47048" />
     <g
        aria-label="PAN"
-       transform="matrix(0.26458333,0,0,0.26458333,23.007072,0.50239354)"
+       transform="matrix(0.26458333,0,0,0.26458333,23.007072,-5.0870232)"
        id="text32150-0"
-       style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect32152-1);fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1">
+       style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect32152-1);fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1">
       <path
          d="m 77.237779,444.10281 q 0,1.08 -0.573332,1.6 -0.573331,0.50666 -1.693329,0.50666 h -1.386663 v 3.62666 h -1.159997 v -9.33331 h 2.519994 q 1.13333,0 1.706662,0.50667 0.586665,0.49333 0.586665,1.57332 z m -1.159997,-1.63999 q 0,-0.50667 -0.239999,-0.73334 -0.226666,-0.22666 -0.733332,-0.22666 h -1.519996 v 3.70665 h 1.519996 q 0.506666,0 0.733332,-0.22666 0.239999,-0.24 0.239999,-0.74667 z"
          id="path69143"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 80.731091,447.47614 -0.519999,2.35999 h -1.186664 l 2.253328,-9.33331 h 1.53333 l 2.213327,9.33331 H 83.83775 l -0.506666,-2.35999 z m 2.38666,-1 -1.09333,-5.09332 -1.079997,5.09332 z"
          id="path69145"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 87.757727,449.83613 h -1.079998 v -9.33331 h 1.893329 l 2.106661,8.34665 v -8.34665 h 1.079998 v 9.33331 h -1.906662 l -2.093328,-8.34665 z"
          id="path69147"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
     </g>
     <rect
-       style="fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0593534;stroke-linejoin:round;stroke-opacity:1"
+       style="fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0461162;stroke-linejoin:round;stroke-opacity:1"
        id="rect1762-9-4-1-2-8-8"
-       width="22.982"
-       height="10.211159"
-       x="60.048698"
-       y="113.18124" />
+       width="21.953411"
+       height="6.4532404"
+       x="60.042057"
+       y="109.47048" />
     <g
        aria-label="PITCH"
-       transform="matrix(0.26458333,0,0,0.26458333,49.819632,0.50239354)"
+       transform="matrix(0.26458333,0,0,0.26458333,49.819632,-5.0870232)"
        id="text32150-0-5"
-       style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect32152-1-3);fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1">
+       style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect32152-1-3);fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1">
       <path
          d="m 70.037811,444.10281 q 0,1.08 -0.573332,1.6 -0.573332,0.50666 -1.693329,0.50666 h -1.386663 v 3.62666 H 65.22449 v -9.33331 h 2.519993 q 1.133331,0 1.706663,0.50667 0.586665,0.49333 0.586665,1.57332 z m -1.159997,-1.63999 q 0,-0.50667 -0.24,-0.73334 -0.226666,-0.22666 -0.733331,-0.22666 h -1.519996 v 3.70665 h 1.519996 q 0.506665,0 0.733331,-0.22666 0.24,-0.24 0.24,-0.74667 z"
          id="path69150"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 74.237787,448.8628 v -7.38665 H 73.03779 v -0.97333 h 3.559991 v 0.97333 h -1.199997 v 7.38665 h 1.199997 v 0.97333 H 73.03779 v -0.97333 z"
          id="path69152"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 81.437756,449.83613 v -8.31998 h -2.119995 v -1.01333 h 5.399987 v 1.01333 h -2.119995 v 8.31998 z"
          id="path69154"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 89.477723,449.83613 q -1.159997,0 -1.786662,-0.56 -0.613332,-0.57333 -0.613332,-1.70666 v -4.79999 q 0,-1.13333 0.613332,-1.69333 0.626665,-0.57333 1.786662,-0.57333 h 1.893329 v 1.01333 H 89.34439 q -0.493332,0 -0.799998,0.29333 -0.306666,0.29334 -0.306666,0.70667 v 5.30665 q 0,0.41333 0.306666,0.70667 0.306666,0.29333 0.799998,0.29333 h 2.026662 v 1.01333 z"
          id="path69156"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 95.051029,445.54281 v 4.29332 h -1.159997 v -9.33331 h 1.159997 v 4.05332 h 2.74666 v -4.05332 h 1.159997 v 9.33331 h -1.159997 v -4.29332 z"
          id="path69158"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
     </g>
     <rect
-       style="fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0593534;stroke-linejoin:round;stroke-opacity:1"
+       style="fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0461165;stroke-linejoin:round;stroke-opacity:1"
        id="rect1762-9-4-1-2-8-8-5"
-       width="22.98173"
-       height="10.211159"
-       x="86.861252"
-       y="113.18124" />
+       width="21.953409"
+       height="6.4532404"
+       x="86.854607"
+       y="109.47048" />
     <g
        aria-label="RATCHET"
-       transform="matrix(0.26458333,0,0,0.26458333,76.646296,0.50239354)"
+       transform="matrix(0.26458333,0,0,0.26458333,76.646296,-5.0870232)"
        id="text32150-0-5-9"
-       style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect32152-1-3-3);fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1">
+       style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect32152-1-3-3);fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1">
       <path
          d="m 58.917852,445.96947 v 3.86666 h -1.159997 v -9.33331 h 2.50666 q 1.133331,0 1.706663,0.50667 0.586665,0.49333 0.586665,1.57332 v 1.28 q 0,1.50666 -1.199997,1.88 l 1.853329,4.09332 h -1.266664 l -1.719996,-3.86666 z m 2.479994,-3.50665 q 0,-0.50667 -0.24,-0.73334 -0.226666,-0.22666 -0.733331,-0.22666 h -1.506663 v 3.46666 h 1.506663 q 0.506665,0 0.733331,-0.22667 0.24,-0.24 0.24,-0.74667 z"
          id="path69161"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 66.331154,447.47614 -0.519999,2.35999 h -1.186664 l 2.253328,-9.33331 h 1.533329 l 2.213328,9.33331 h -1.186663 l -0.506666,-2.35999 z m 2.38666,-1 -1.09333,-5.09332 -1.079998,5.09332 z"
          id="path69163"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 74.237787,449.83613 v -8.31998 h -2.119994 v -1.01333 h 5.399986 v 1.01333 h -2.119995 v 8.31998 z"
          id="path69165"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 82.277755,449.83613 q -1.159998,0 -1.786663,-0.56 -0.613331,-0.57333 -0.613331,-1.70666 v -4.79999 q 0,-1.13333 0.613331,-1.69333 0.626665,-0.57333 1.786663,-0.57333 h 1.893328 v 1.01333 h -2.026661 q -0.493333,0 -0.799998,0.29333 -0.306666,0.29334 -0.306666,0.70667 v 5.30665 q 0,0.41333 0.306666,0.70667 0.306665,0.29333 0.799998,0.29333 h 2.026661 v 1.01333 z"
          id="path69167"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 87.85106,445.54281 v 4.29332 h -1.159997 v -9.33331 h 1.159997 v 4.05332 h 2.74666 v -4.05332 h 1.159997 v 9.33331 H 90.59772 v -4.29332 z"
          id="path69169"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 98.65102,440.50282 v 0.97333 h -3.293325 v 3.05333 h 2.959992 v 0.97333 h -2.959992 v 3.35999 h 3.293325 v 0.97333 h -4.453323 v -9.33331 z"
          id="path69171"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 103.03766,449.83613 v -8.31998 h -2.11999 v -1.01333 h 5.39999 v 1.01333 h -2.12 v 8.31998 z"
          id="path69173"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
     </g>
     <rect
-       style="fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0593534;stroke-linejoin:round;stroke-opacity:1"
+       style="fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0461165;stroke-linejoin:round;stroke-opacity:1"
        id="rect1762-9-4-1-2-8-8-5-3"
-       width="22.98173"
-       height="10.211159"
-       x="113.67381"
-       y="113.18124" />
+       width="21.953403"
+       height="6.4532452"
+       x="113.66718"
+       y="109.47044" />
     <g
        aria-label="OFFSET"
-       transform="matrix(0.26458333,0,0,0.26458333,103.45885,0.50239353)"
+       transform="matrix(0.26458333,0,0,0.26458333,103.45885,-5.0870232)"
        id="text32150-0-5-9-4"
-       style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect32152-1-3-3-0);fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1">
+       style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect32152-1-3-3-0);fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1">
       <path
          d="m 66.691159,447.56947 q 0,1.13333 -0.626665,1.70666 -0.613332,0.56 -1.773329,0.56 h -0.533332 q -1.159997,0 -1.786662,-0.56 -0.613332,-0.57333 -0.613332,-1.70666 v -4.79999 q 0,-1.13333 0.613332,-1.69333 0.626665,-0.57333 1.786662,-0.57333 h 0.533332 q 1.159997,0 1.773329,0.57333 0.626665,0.56 0.626665,1.69333 z m -1.159997,-5.05332 q 0,-0.41333 -0.306666,-0.70667 -0.306666,-0.29333 -0.799998,-0.29333 H 63.6245 q -0.493332,0 -0.799998,0.29333 -0.306666,0.29334 -0.306666,0.70667 v 5.30665 q 0,0.41333 0.306666,0.70667 0.306666,0.29333 0.799998,0.29333 h 0.799998 q 0.493332,0 0.799998,-0.29333 0.306666,-0.29334 0.306666,-0.70667 z"
          id="path69176"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 73.157796,444.66281 v 0.97333 h -2.959992 v 4.19999 h -1.159997 v -9.33331 h 4.453322 v 0.97333 h -3.293325 v 3.18666 z"
          id="path69178"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 80.357765,444.66281 v 0.97333 h -2.959992 v 4.19999 h -1.159997 v -9.33331 h 4.453322 v 0.97333 h -3.293325 v 3.18666 z"
          id="path69180"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 87.877734,447.56947 q 0,1.13333 -0.626665,1.70666 -0.613332,0.56 -1.773329,0.56 h -1.893329 v -1.01333 h 2.026662 q 0.493332,0 0.799998,-0.29333 0.306666,-0.29334 0.306666,-0.70667 v -1.38666 q 0,-0.4 -0.213333,-0.64 -0.2,-0.25333 -0.613332,-0.25333 h -0.399999 q -0.986664,0 -1.559996,-0.57333 -0.573332,-0.58667 -0.573332,-1.69333 v -0.50667 q 0,-1.13333 0.613332,-1.69333 0.626665,-0.57333 1.786662,-0.57333 h 1.906662 v 1.01333 h -2.039995 q -0.493332,0 -0.799998,0.29333 -0.306666,0.29334 -0.306666,0.70667 v 1.01333 q 0,0.41333 0.266666,0.69333 0.266666,0.26667 0.693332,0.26667 h 0.399999 q 0.946664,0 1.466663,0.54666 0.533332,0.54667 0.533332,1.65333 z"
          id="path69182"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 95.051036,440.50282 v 0.97333 h -3.293325 v 3.05333 h 2.959992 v 0.97333 h -2.959992 v 3.35999 h 3.293325 v 0.97333 h -4.453323 v -9.33331 z"
          id="path69184"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 99.437678,449.83613 v -8.31998 h -2.119995 v -1.01333 h 5.399987 v 1.01333 h -2.12 v 8.31998 z"
          id="path69186"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
     </g>
     <rect
-       style="fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0593534;stroke-linejoin:round;stroke-opacity:1"
+       style="fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0461165;stroke-linejoin:round;stroke-opacity:1"
        id="rect1762-9-4-1-2-8-8-5-3-9-3"
-       width="22.98173"
-       height="10.211159"
-       x="167.29892"
-       y="113.18124" />
+       width="21.953417"
+       height="6.4532452"
+       x="167.3008"
+       y="109.47044" />
     <g
        aria-label="LOOP"
-       transform="matrix(0.26458333,0,0,0.26458333,157.04163,0.50239354)"
+       transform="matrix(0.26458333,0,0,0.26458333,157.04163,-5.0870232)"
        id="text32150-0-5-9-4-4"
-       style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect32152-1-3-3-0-0);fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1">
+       style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect32152-1-3-3-0-0);fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1">
       <path
          d="m 70.317803,440.50282 v 8.31998 h 2.973326 v 1.01333 h -4.133323 v -9.33331 z"
          id="path69200"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 81.091097,447.56947 q 0,1.13333 -0.626666,1.70666 -0.613331,0.56 -1.773328,0.56 h -0.533332 q -1.159997,0 -1.786663,-0.56 -0.613331,-0.57333 -0.613331,-1.70666 v -4.79999 q 0,-1.13333 0.613331,-1.69333 0.626666,-0.57333 1.786663,-0.57333 h 0.533332 q 1.159997,0 1.773328,0.57333 0.626666,0.56 0.626666,1.69333 z m -1.159998,-5.05332 q 0,-0.41333 -0.306665,-0.70667 -0.306666,-0.29333 -0.799998,-0.29333 h -0.799998 q -0.493332,0 -0.799998,0.29333 -0.306666,0.29334 -0.306666,0.70667 v 5.30665 q 0,0.41333 0.306666,0.70667 0.306666,0.29333 0.799998,0.29333 h 0.799998 q 0.493332,0 0.799998,-0.29333 0.306665,-0.29334 0.306665,-0.70667 z"
          id="path69202"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 88.291065,447.56947 q 0,1.13333 -0.626665,1.70666 -0.613332,0.56 -1.773329,0.56 h -0.533332 q -1.159997,0 -1.786662,-0.56 -0.613331,-0.57333 -0.613331,-1.70666 v -4.79999 q 0,-1.13333 0.613331,-1.69333 0.626665,-0.57333 1.786662,-0.57333 h 0.533332 q 1.159997,0 1.773329,0.57333 0.626665,0.56 0.626665,1.69333 z m -1.159997,-5.05332 q 0,-0.41333 -0.306666,-0.70667 -0.306665,-0.29333 -0.799998,-0.29333 h -0.799998 q -0.493332,0 -0.799998,0.29333 -0.306665,0.29334 -0.306665,0.70667 v 5.30665 q 0,0.41333 0.306665,0.70667 0.306666,0.29333 0.799998,0.29333 h 0.799998 q 0.493333,0 0.799998,-0.29333 0.306666,-0.29334 0.306666,-0.70667 z"
          id="path69204"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 95.237702,444.10281 q 0,1.08 -0.573332,1.6 -0.573332,0.50666 -1.693329,0.50666 h -1.386663 v 3.62666 h -1.159997 v -9.33331 h 2.519993 q 1.133331,0 1.706663,0.50667 0.586665,0.49333 0.586665,1.57332 z m -1.159997,-1.63999 q 0,-0.50667 -0.24,-0.73334 -0.226666,-0.22666 -0.733331,-0.22666 h -1.519996 v 3.70665 h 1.519996 q 0.506665,0 0.733331,-0.22666 0.24,-0.24 0.24,-0.74667 z"
          id="path69206"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
     </g>
     <rect
-       style="fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0593534;stroke-linejoin:round;stroke-opacity:1"
+       style="fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0461165;stroke-linejoin:round;stroke-opacity:1"
        id="rect1762-9-4-1-2-8-8-5-3-9-3-7"
-       width="22.98173"
-       height="10.211159"
-       x="194.11148"
-       y="113.18124" />
+       width="21.953417"
+       height="6.4532404"
+       x="194.10484"
+       y="109.47048" />
     <g
        aria-label="REVERSE"
-       transform="matrix(0.26458333,0,0,0.26458333,183.95826,0.50239353)"
+       transform="matrix(0.26458333,0,0,0.26458333,183.95826,-5.0870232)"
        id="text32150-0-5-9-4-4-1"
-       style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect32152-1-3-3-0-0-2);fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1">
+       style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect32152-1-3-3-0-0-2);fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1">
       <path
          d="m 58.917852,445.96947 v 3.86666 h -1.159997 v -9.33331 h 2.50666 q 1.133331,0 1.706663,0.50667 0.586665,0.49333 0.586665,1.57332 v 1.28 q 0,1.50666 -1.199997,1.88 l 1.853329,4.09332 h -1.266664 l -1.719996,-3.86666 z m 2.479994,-3.50665 q 0,-0.50667 -0.24,-0.73334 -0.226666,-0.22666 -0.733331,-0.22666 h -1.506663 v 3.46666 h 1.506663 q 0.506665,0 0.733331,-0.22667 0.24,-0.24 0.24,-0.74667 z"
          id="path69209"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 69.851145,440.50282 v 0.97333 H 66.55782 v 3.05333 h 2.959992 v 0.97333 H 66.55782 v 3.35999 h 3.293325 v 0.97333 h -4.453322 v -9.33331 z"
          id="path69211"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 71.971126,440.50282 h 1.173331 l 1.599996,8.15998 1.719995,-8.15998 h 1.146664 l -2.093328,9.33331 h -1.586663 z"
          id="path69213"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 84.251083,440.50282 v 0.97333 h -3.293325 v 3.05333 h 2.959992 v 0.97333 h -2.959992 v 3.35999 h 3.293325 v 0.97333 h -4.453322 v -9.33331 z"
          id="path69215"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 87.717727,445.96947 v 3.86666 H 86.55773 v -9.33331 h 2.506661 q 1.13333,0 1.706662,0.50667 0.586665,0.49333 0.586665,1.57332 v 1.28 q 0,1.50666 -1.199997,1.88 l 1.853329,4.09332 h -1.266664 l -1.719995,-3.86666 z m 2.479994,-3.50665 q 0,-0.50667 -0.239999,-0.73334 -0.226666,-0.22666 -0.733332,-0.22666 h -1.506663 v 3.46666 h 1.506663 q 0.506666,0 0.733332,-0.22667 0.239999,-0.24 0.239999,-0.74667 z"
          id="path69217"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 98.677686,447.56947 q 0,1.13333 -0.626665,1.70666 -0.613332,0.56 -1.773329,0.56 h -1.893328 v -1.01333 h 2.026661 q 0.493332,0 0.799998,-0.29333 0.306666,-0.29334 0.306666,-0.70667 v -1.38666 q 0,-0.4 -0.213333,-0.64 -0.199999,-0.25333 -0.613331,-0.25333 h -0.399999 q -0.986665,0 -1.559997,-0.57333 -0.573331,-0.58667 -0.573331,-1.69333 v -0.50667 q 0,-1.13333 0.613331,-1.69333 0.626665,-0.57333 1.786663,-0.57333 h 1.906661 v 1.01333 h -2.039994 q -0.493333,0 -0.799998,0.29333 -0.306666,0.29334 -0.306666,0.70667 v 1.01333 q 0,0.41333 0.266666,0.69333 0.266666,0.26667 0.693331,0.26667 h 0.399999 q 0.946665,0 1.466663,0.54666 0.533332,0.54667 0.533332,1.65333 z"
          id="path69219"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 105.85099,440.50282 v 0.97333 h -3.29333 v 3.05333 h 2.96 v 0.97333 h -2.96 v 3.35999 h 3.29333 v 0.97333 h -4.45332 v -9.33331 z"
          id="path69221"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
     </g>
     <rect
-       style="fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0593534;stroke-linejoin:round;stroke-opacity:1"
+       style="fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0461165;stroke-linejoin:round;stroke-opacity:1"
        id="rect1762-9-4-1-2-8-8-5-3-9"
-       width="22.98173"
-       height="10.211159"
-       x="140.48636"
-       y="113.18124" />
+       width="21.953417"
+       height="6.4532452"
+       x="140.48398"
+       y="109.47044" />
     <g
        aria-label="PROB %"
-       transform="matrix(0.26458333,0,0,0.26458333,128.68908,0.50239354)"
+       transform="matrix(0.26458333,0,0,0.26458333,128.68908,-5.0870232)"
        id="text32150-0-5-9-4-7"
-       style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect32152-1-3-3-0-5);fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1">
+       style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect32152-1-3-3-0-5);fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1">
       <path
          d="m 71.918295,444.10281 q 0,1.08 -0.573332,1.6 -0.573332,0.50666 -1.693329,0.50666 h -1.386663 v 3.62666 h -1.159997 v -9.33331 h 2.519994 q 1.13333,0 1.706662,0.50667 0.586665,0.49333 0.586665,1.57332 z m -1.159997,-1.63999 q 0,-0.50667 -0.239999,-0.73334 -0.226666,-0.22666 -0.733332,-0.22666 h -1.519996 v 3.70665 h 1.519996 q 0.506666,0 0.733332,-0.22666 0.239999,-0.24 0.239999,-0.74667 z"
          id="path69189"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 75.198274,445.96947 v 3.86666 h -1.159997 v -9.33331 h 2.50666 q 1.133331,0 1.706663,0.50667 0.586665,0.49333 0.586665,1.57332 v 1.28 q 0,1.50666 -1.199997,1.88 l 1.853328,4.09332 h -1.266663 l -1.719996,-3.86666 z m 2.479994,-3.50665 q 0,-0.50667 -0.24,-0.73334 -0.226666,-0.22666 -0.733331,-0.22666 h -1.506663 v 3.46666 h 1.506663 q 0.506665,0 0.733331,-0.22667 0.24,-0.24 0.24,-0.74667 z"
          id="path69191"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 86.571566,447.56947 q 0,1.13333 -0.626666,1.70666 -0.613331,0.56 -1.773328,0.56 H 83.63824 q -1.159997,0 -1.786663,-0.56 -0.613331,-0.57333 -0.613331,-1.70666 v -4.79999 q 0,-1.13333 0.613331,-1.69333 0.626666,-0.57333 1.786663,-0.57333 h 0.533332 q 1.159997,0 1.773328,0.57333 0.626666,0.56 0.626666,1.69333 z m -1.159998,-5.05332 q 0,-0.41333 -0.306665,-0.70667 -0.306666,-0.29333 -0.799998,-0.29333 h -0.799998 q -0.493332,0 -0.799998,0.29333 -0.306666,0.29334 -0.306666,0.70667 v 5.30665 q 0,0.41333 0.306666,0.70667 0.306666,0.29333 0.799998,0.29333 h 0.799998 q 0.493332,0 0.799998,-0.29333 0.306665,-0.29334 0.306665,-0.70667 z"
          id="path69193"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 93.571535,447.72947 q 0,1.14666 -0.533332,1.62666 -0.519998,0.48 -1.733329,0.48 h -2.66666 v -9.33331 h 2.506661 q 1.186663,0 1.733329,0.48 0.559998,0.48 0.559998,1.59999 v 0.76 q 0,1.02667 -0.733331,1.54667 0.866664,0.47999 0.866664,1.63999 z m -1.29333,-5.26665 q 0,-0.50667 -0.239999,-0.73334 -0.226666,-0.22666 -0.733332,-0.22666 h -1.506662 v 2.94666 h 1.506662 q 0.413333,0 0.693332,-0.26667 0.279999,-0.26667 0.279999,-0.70666 z m 0.133333,3.94665 q 0,-0.44 -0.266666,-0.69333 -0.266666,-0.26667 -0.706665,-0.26667 h -1.639995 v 3.38666 h 1.626662 q 0.506665,0 0.746665,-0.22666 0.239999,-0.24 0.239999,-0.74667 z"
          id="path69195"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
       <path
          d="m 105.75814,442.74281 q 0,0.84 -0.42666,1.28 -0.42667,0.42667 -1.2,0.42667 h -0.10666 q -0.77334,0 -1.2,-0.42667 -0.42667,-0.44 -0.42667,-1.28 v -0.53333 q 0,-0.84 0.42667,-1.26666 0.42666,-0.44 1.2,-0.44 h 0.10666 q 0.77333,0 1.2,0.44 0.42666,0.42666 0.42666,1.26666 z m -0.93333,-0.67999 q 0,-0.33334 -0.17333,-0.54667 -0.17333,-0.21333 -0.52,-0.21333 h -0.10666 q -0.34667,0 -0.52,0.21333 -0.17334,0.21333 -0.17334,0.54667 v 0.82666 q 0,0.33333 0.17334,0.54667 0.17333,0.21333 0.52,0.21333 h 0.10666 q 0.34667,0 0.52,-0.21333 0.17333,-0.21334 0.17333,-0.54667 z m 4.10666,2.22666 v 0.82666 l -6.86665,0.97333 v -0.82666 z m -0.37333,3.83999 q 0,0.84 -0.42667,1.27999 -0.42666,0.42667 -1.2,0.42667 h -0.10666 q -0.77333,0 -1.2,-0.42667 -0.42666,-0.43999 -0.42666,-1.27999 v -0.53333 q 0,-0.84 0.42666,-1.26667 0.42667,-0.44 1.2,-0.44 h 0.10666 q 0.77334,0 1.2,0.44 0.42667,0.42667 0.42667,1.26667 z m -0.93333,-0.68 q 0,-0.33333 -0.17334,-0.54667 -0.17333,-0.21333 -0.52,-0.21333 h -0.10666 q -0.34667,0 -0.52,0.21333 -0.17333,0.21334 -0.17333,0.54667 v 0.82666 q 0,0.33334 0.17333,0.54667 0.17333,0.21333 0.52,0.21333 h 0.10666 q 0.34667,0 0.52,-0.21333 0.17334,-0.21333 0.17334,-0.54667 z"
          id="path69197"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         style="fill:#bfbfbf;fill-opacity:1;stroke:none;stroke-opacity:1" />
     </g>
+    <rect
+       style="display:inline;fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0461191;stroke-linejoin:round;stroke-opacity:1"
+       id="rect1762-9-4-1-2-6"
+       width="21.95388"
+       height="6.4538369"
+       x="6.4190593"
+       y="119.01011" />
+    <g
+       aria-label="ATTACK"
+       transform="matrix(0.26458333,0,0,0.26458333,32.207928,-10.763273)"
+       id="text7878"
+       style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect7880);fill:#bfbfbf">
+      <path
+         d="m -72.856721,505.10504 -0.519999,2.36 h -1.186664 l 2.253328,-9.33331 h 1.533329 l 2.213328,9.33331 h -1.186664 l -0.506665,-2.36 z m 2.38666,-1 -1.09333,-5.09332 -1.079998,5.09332 z"
+         style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect7880);fill:#bfbfbf"
+         id="path17147" />
+      <path
+         d="m -64.950088,507.46504 v -8.31998 h -2.119994 v -1.01333 h 5.399986 v 1.01333 h -2.119995 v 8.31998 z"
+         style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect7880);fill:#bfbfbf"
+         id="path17149" />
+      <path
+         d="m -57.750119,507.46504 v -8.31998 h -2.119995 v -1.01333 h 5.399987 v 1.01333 h -2.119995 v 8.31998 z"
+         style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect7880);fill:#bfbfbf"
+         id="path17151" />
+      <path
+         d="m -51.256815,505.10504 -0.519998,2.36 h -1.186664 l 2.253328,-9.33331 h 1.533329 l 2.213328,9.33331 h -1.186664 l -0.506665,-2.36 z m 2.386661,-1 -1.09333,-5.09332 -1.079998,5.09332 z"
+         style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect7880);fill:#bfbfbf"
+         id="path17153" />
+      <path
+         d="m -42.510183,507.46504 q -1.159998,0 -1.786663,-0.56 -0.613331,-0.57333 -0.613331,-1.70666 v -4.79999 q 0,-1.13333 0.613331,-1.69333 0.626665,-0.57333 1.786663,-0.57333 h 1.893328 v 1.01333 h -2.026661 q -0.493333,0 -0.799998,0.29333 -0.306666,0.29333 -0.306666,0.70666 v 5.30666 q 0,0.41333 0.306666,0.70666 0.306665,0.29334 0.799998,0.29334 h 2.026661 v 1.01333 z"
+         style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect7880);fill:#bfbfbf"
+         id="path17155" />
+      <path
+         d="m -36.923544,504.02504 v 3.44 h -1.159997 v -9.33331 h 1.159997 v 4.02665 l 2.533327,-4.02665 h 1.266663 l -2.573327,4.11999 2.733327,5.21332 h -1.33333 l -2.119995,-4.19999 z"
+         style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect7880);fill:#bfbfbf"
+         id="path17157" />
+    </g>
+    <rect
+       style="display:inline;fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0461163;stroke-linejoin:round;stroke-opacity:1"
+       id="rect1762-9-4-1-2-8-0"
+       width="21.953409"
+       height="6.4531965"
+       x="33.229027"
+       y="119.01075" />
+    <rect
+       style="display:inline;fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.046116;stroke-linejoin:round;stroke-opacity:1"
+       id="rect1762-9-4-1-2-8-8-7"
+       width="21.953411"
+       height="6.4531965"
+       x="60.041584"
+       y="119.01075" />
+    <rect
+       style="display:inline;fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0461163;stroke-linejoin:round;stroke-opacity:1"
+       id="rect1762-9-4-1-2-8-8-5-36"
+       width="21.953409"
+       height="6.4531965"
+       x="86.854134"
+       y="119.01075" />
+    <rect
+       style="display:inline;fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0461163;stroke-linejoin:round;stroke-opacity:1"
+       id="rect1762-9-4-1-2-8-8-5-3-5"
+       width="21.953403"
+       height="6.4532013"
+       x="113.66669"
+       y="119.0107" />
+    <rect
+       style="display:inline;fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0461163;stroke-linejoin:round;stroke-opacity:1"
+       id="rect1762-9-4-1-2-8-8-5-3-9-3-9"
+       width="21.953417"
+       height="6.4532013"
+       x="167.30032"
+       y="119.0107" />
+    <rect
+       style="display:inline;fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0461163;stroke-linejoin:round;stroke-opacity:1"
+       id="rect1762-9-4-1-2-8-8-5-3-9-3-7-1"
+       width="21.953417"
+       height="6.4531965"
+       x="194.10439"
+       y="119.01075" />
+    <rect
+       style="display:inline;fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.0461163;stroke-linejoin:round;stroke-opacity:1"
+       id="rect1762-9-4-1-2-8-8-5-3-9-4"
+       width="21.953417"
+       height="6.4532013"
+       x="140.48351"
+       y="119.0107" />
     <text
        xml:space="preserve"
        style="font-size:4.23333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';letter-spacing:0px;word-spacing:0px;stroke-width:0.264583"
@@ -1158,6 +1263,27 @@
       <path
          d="m 674.66795,66.238091 v -6.552 l -1.692,0.624 v -0.972 l 1.572,-0.6 h 1.14 v 7.5 h 1.308 v 0.9 h -3.9 v -0.9 z"
          id="path49605" />
+    </g>
+    <g
+       aria-label="DECAY"
+       transform="matrix(0.26458333,0,0,0.26458333,59.137939,-10.728423)"
+       id="text7878-0"
+       style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect7880-5);display:inline;fill:#bfbfbf">
+      <path
+         d="m -65.456747,505.35837 q 0,1.14667 -0.533332,1.62667 -0.519998,0.48 -1.733329,0.48 h -2.746659 v -9.33331 h 2.58666 q 1.199997,0 1.813328,0.49333 0.613332,0.48 0.613332,1.58666 z m -1.159997,-5.26665 q 0,-0.44 -0.266666,-0.69333 -0.266666,-0.26667 -0.706665,-0.26667 h -1.719995 v 7.33332 h 1.706662 q 0.506665,0 0.746665,-0.22667 0.239999,-0.24 0.239999,-0.74666 z"
+         id="path17118" />
+      <path
+         d="m -58.536777,498.13173 v 0.97333 h -3.293325 v 3.05332 h 2.959992 v 0.97333 h -2.959992 v 3.36 h 3.293325 v 0.97333 h -4.453322 v -9.33331 z"
+         id="path17120" />
+      <path
+         d="m -53.310137,507.46504 q -1.159997,0 -1.786662,-0.56 -0.613332,-0.57333 -0.613332,-1.70666 v -4.79999 q 0,-1.13333 0.613332,-1.69333 0.626665,-0.57333 1.786662,-0.57333 h 1.893329 v 1.01333 h -2.026662 q -0.493332,0 -0.799998,0.29333 -0.306666,0.29333 -0.306666,0.70666 v 5.30666 q 0,0.41333 0.306666,0.70666 0.306666,0.29334 0.799998,0.29334 h 2.026662 v 1.01333 z"
+         id="path17122" />
+      <path
+         d="m -47.65683,505.10504 -0.519999,2.36 h -1.186664 l 2.253328,-9.33331 h 1.533329 l 2.213328,9.33331 h -1.186663 l -0.506666,-2.36 z m 2.38666,-1 -1.09333,-5.09332 -1.079997,5.09332 z"
+         id="path17124" />
+      <path
+         d="m -39.790197,507.46504 v -4.33333 l -2.386661,-4.99998 h 1.279997 l 1.759996,3.87999 1.759995,-3.87999 h 1.213331 l -2.426661,4.99998 v 4.33333 z"
+         id="path17126" />
     </g>
   </g>
   <g

--- a/res/groove_box_front_panel.svg
+++ b/res/groove_box_front_panel.svg
@@ -234,9 +234,9 @@
      inkscape:document-rotation="0"
      inkscape:current-layer="layer1"
      inkscape:document-units="mm"
-     inkscape:cy="485.25"
-     inkscape:cx="321.5"
-     inkscape:zoom="4"
+     inkscape:cy="443.5"
+     inkscape:cx="179.5"
+     inkscape:zoom="8"
      inkscape:pageshadow="2"
      inkscape:pageopacity="1"
      borderopacity="1.0"
@@ -539,13 +539,13 @@
        style="font-size:16px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect5909-1)"><tspan
          x="514.5"
          y="140.06433"
-         id="tspan17681">
+         id="tspan11089">
 </tspan><tspan
          x="514.5"
          y="174.56433"
-         id="tspan17685"><tspan
+         id="tspan11093"><tspan
            dx="0 8.6399841 8.6399841 8.6399841 8.6399841 8.6399841"
-           id="tspan17683">CSnare</tspan></tspan></text>
+           id="tspan11091">CSnare</tspan></tspan></text>
     <text
        xml:space="preserve"
        transform="matrix(0.26458333,0,0,0.26458333,26.405231,1.7443286)"
@@ -553,9 +553,9 @@
        style="font-size:16px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect26191-3)"><tspan
          x="81.669922"
          y="121.69128"
-         id="tspan17689"><tspan
+         id="tspan11097"><tspan
            dx="0 8.6399841 8.6399841 8.6399841 8.6399841 8.6399841 8.6399841 8.6399841 8.6399841 8.6399841 8.6399841 8.6399841 8.6399841"
-           id="tspan17687">Global Memory</tspan></tspan></text>
+           id="tspan11095">Global Memory</tspan></tspan></text>
     <rect
        style="fill:#414141;fill-opacity:1;fill-rule:evenodd;stroke-width:0.315795;stroke-linejoin:round"
        id="rect1762"
@@ -1265,25 +1265,37 @@
          id="path49605" />
     </g>
     <g
-       aria-label="DECAY"
-       transform="matrix(0.26458333,0,0,0.26458333,59.137939,-10.728423)"
-       id="text7878-0"
-       style="font-size:13.3333px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;shape-inside:url(#rect7880-5);display:inline;fill:#bfbfbf">
+       aria-label="RELEASE"
+       id="text3939"
+       style="font-size:3.52778px;line-height:1.25;font-family:'Share Tech Mono';-inkscape-font-specification:'Share Tech Mono, Normal';letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
       <path
-         d="m -65.456747,505.35837 q 0,1.14667 -0.533332,1.62667 -0.519998,0.48 -1.733329,0.48 h -2.746659 v -9.33331 h 2.58666 q 1.199997,0 1.813328,0.49333 0.613332,0.48 0.613332,1.58666 z m -1.159997,-5.26665 q 0,-0.44 -0.266666,-0.69333 -0.266666,-0.26667 -0.706665,-0.26667 h -1.719995 v 7.33332 h 1.706662 q 0.506665,0 0.746665,-0.22667 0.239999,-0.24 0.239999,-0.74666 z"
-         id="path17118" />
+         d="m 39.199564,122.51538 v 1.02306 h -0.306917 v -2.46945 h 0.663223 q 0.299861,0 0.451555,0.13406 0.155223,0.13052 0.155223,0.41627 v 0.33867 q 0,0.39864 -0.3175,0.49742 l 0.490361,1.08303 H 40.00037 l -0.455084,-1.02306 z m 0.656167,-0.92781 q 0,-0.13405 -0.0635,-0.19402 -0.05997,-0.06 -0.194028,-0.06 h -0.398639 v 0.91723 h 0.398639 q 0.134056,0 0.194028,-0.06 0.0635,-0.0635 0.0635,-0.19755 z"
+         style="fill:#bfbfbf"
+         id="path10551" />
       <path
-         d="m -58.536777,498.13173 v 0.97333 h -3.293325 v 3.05332 h 2.959992 v 0.97333 h -2.959992 v 3.36 h 3.293325 v 0.97333 h -4.453322 v -9.33331 z"
-         id="path17120" />
+         d="m 42.09234,121.06899 v 0.25753 h -0.871362 v 0.80786 h 0.783167 v 0.25753 h -0.783167 v 0.889 h 0.871362 v 0.25753 h -1.178279 v -2.46945 z"
+         style="fill:#bfbfbf"
+         id="path10553" />
       <path
-         d="m -53.310137,507.46504 q -1.159997,0 -1.786662,-0.56 -0.613332,-0.57333 -0.613332,-1.70666 v -4.79999 q 0,-1.13333 0.613332,-1.69333 0.626665,-0.57333 1.786662,-0.57333 h 1.893329 v 1.01333 h -2.026662 q -0.493332,0 -0.799998,0.29333 -0.306666,0.29333 -0.306666,0.70666 v 5.30666 q 0,0.41333 0.306666,0.70666 0.306666,0.29334 0.799998,0.29334 h 2.026662 v 1.01333 z"
-         id="path17122" />
+         d="m 43.168309,121.06899 v 2.20134 h 0.786695 v 0.26811 h -1.093612 v -2.46945 z"
+         style="fill:#bfbfbf"
+         id="path10555" />
       <path
-         d="m -47.65683,505.10504 -0.519999,2.36 h -1.186664 l 2.253328,-9.33331 h 1.533329 l 2.213328,9.33331 h -1.186663 l -0.506666,-2.36 z m 2.38666,-1 -1.09333,-5.09332 -1.079997,5.09332 z"
-         id="path17124" />
+         d="m 45.902335,121.06899 v 0.25753 h -0.871361 v 0.80786 h 0.783167 v 0.25753 h -0.783167 v 0.889 h 0.871361 v 0.25753 h -1.178278 v -2.46945 z"
+         style="fill:#bfbfbf"
+         id="path10557" />
       <path
-         d="m -39.790197,507.46504 v -4.33333 l -2.386661,-4.99998 h 1.279997 l 1.759996,3.87999 1.759995,-3.87999 h 1.213331 l -2.426661,4.99998 v 4.33333 z"
-         id="path17126" />
+         d="m 46.875999,122.91402 -0.137583,0.62442 h -0.313973 l 0.596195,-2.46945 h 0.405695 l 0.585611,2.46945 h -0.313972 l -0.134056,-0.62442 z m 0.631473,-0.26458 -0.289278,-1.34762 -0.28575,1.34762 z"
+         style="fill:#bfbfbf"
+         id="path10559" />
+      <path
+         d="m 49.719386,122.93871 q 0,0.29987 -0.165806,0.45156 -0.162278,0.14817 -0.469194,0.14817 h -0.500945 v -0.26811 h 0.536222 q 0.130528,0 0.211667,-0.0776 0.08114,-0.0776 0.08114,-0.18697 v -0.36689 q 0,-0.10583 -0.05644,-0.16933 -0.05292,-0.067 -0.162278,-0.067 h -0.105834 q -0.261055,0 -0.41275,-0.15169 -0.151694,-0.15523 -0.151694,-0.44803 v -0.13406 q 0,-0.29986 0.162277,-0.44802 0.165806,-0.1517 0.472723,-0.1517 h 0.504473 v 0.26811 h -0.539751 q -0.130528,0 -0.211667,0.0776 -0.08114,0.0776 -0.08114,0.18698 v 0.26811 q 0,0.10936 0.07056,0.18344 0.07056,0.0706 0.183445,0.0706 h 0.105833 q 0.250472,0 0.388056,0.14464 0.141111,0.14464 0.141111,0.43744 z"
+         style="fill:#bfbfbf"
+         id="path10561" />
+      <path
+         d="m 51.617328,121.06899 v 0.25753 h -0.871361 v 0.80786 h 0.783167 v 0.25753 h -0.783167 v 0.889 h 0.871361 v 0.25753 H 50.43905 v -2.46945 z"
+         style="fill:#bfbfbf"
+         id="path10563" />
     </g>
   </g>
   <g

--- a/src/Common/dsp/ADSR.cpp
+++ b/src/Common/dsp/ADSR.cpp
@@ -1,0 +1,82 @@
+//
+//  ADSR.cpp
+//
+//  Created by Nigel Redmon on 12/18/12.
+//  EarLevel Engineering: earlevel.com
+//  Copyright 2012 Nigel Redmon
+//
+//  For a complete explanation of the ADSR envelope generator and code,
+//  read the series of articles by the author, starting here:
+//  http://www.earlevel.com/main/2013/06/01/envelope-generators/
+//
+//  License:
+//
+//  This source code is provided as is, without warranty.
+//  You may copy and distribute verbatim copies of this document.
+//  You may modify and use this source code to create binary code for your own purposes, free or commercial.
+//
+//  1.01  2016-01-02  njr   added calcCoef to SetTargetRatio functions that were in the ADSR widget but missing in this code
+//  1.02  2017-01-04  njr   in calcCoef, checked for rate 0, to support non-IEEE compliant compilers
+//  1.03  2020-04-08  njr   changed float to double; large target ratio and rate resulted in exp returning 1 in calcCoef
+//
+
+#include "ADSR.h"
+#include <math.h>
+
+ADSR::ADSR(void) {
+    reset();
+    setAttackRate(0);
+    setDecayRate(0);
+    setReleaseRate(0);
+    setSustainLevel(1.0);
+    setTargetRatioA(0.3);
+    setTargetRatioDR(0.0001);
+}
+
+ADSR::~ADSR(void) {
+}
+
+void ADSR::setAttackRate(double rate) {
+    attackRate = rate;
+    attackCoef = calcCoef(rate, targetRatioA);
+    attackBase = (1.0 + targetRatioA) * (1.0 - attackCoef);
+}
+
+void ADSR::setDecayRate(double rate) {
+    decayRate = rate;
+    decayCoef = calcCoef(rate, targetRatioDR);
+    decayBase = (sustainLevel - targetRatioDR) * (1.0 - decayCoef);
+}
+
+void ADSR::setReleaseRate(double rate) {
+    releaseRate = rate;
+    releaseCoef = calcCoef(rate, targetRatioDR);
+    releaseBase = -targetRatioDR * (1.0 - releaseCoef);
+}
+
+double ADSR::calcCoef(double rate, double targetRatio) {
+    return (rate <= 0) ? 0.0 : exp(-log((1.0 + targetRatio) / targetRatio) / rate);
+}
+
+void ADSR::setSustainLevel(double level) {
+    sustainLevel = level;
+    decayBase = (sustainLevel - targetRatioDR) * (1.0 - decayCoef);
+}
+
+void ADSR::setTargetRatioA(double targetRatio) {
+    if (targetRatio < 0.000000001)
+        targetRatio = 0.000000001;  // -180 dB
+    targetRatioA = targetRatio;
+    attackCoef = calcCoef(attackRate, targetRatioA);
+    attackBase = (1.0 + targetRatioA) * (1.0 - attackCoef);
+}
+
+void ADSR::setTargetRatioDR(double targetRatio) {
+    if (targetRatio < 0.000000001)
+        targetRatio = 0.000000001;  // -180 dB
+    targetRatioDR = targetRatio;
+    decayCoef = calcCoef(decayRate, targetRatioDR);
+    releaseCoef = calcCoef(releaseRate, targetRatioDR);
+    decayBase = (sustainLevel - targetRatioDR) * (1.0 - decayCoef);
+    releaseBase = -targetRatioDR * (1.0 - releaseCoef);
+}

--- a/src/Common/dsp/ADSR.h
+++ b/src/Common/dsp/ADSR.h
@@ -1,0 +1,120 @@
+//
+//  ADRS.h
+//
+//  Created by Nigel Redmon on 12/18/12.
+//  EarLevel Engineering: earlevel.com
+//  Copyright 2012 Nigel Redmon
+//
+//  For a complete explanation of the ADSR envelope generator and code,
+//  read the series of articles by the author, starting here:
+//  http://www.earlevel.com/main/2013/06/01/envelope-generators/
+//
+//  License:
+//
+//  This source code is provided as is, without warranty.
+//  You may copy and distribute verbatim copies of this document.
+//  You may modify and use this source code to create binary code for your own purposes, free or commercial.
+//
+//  1.01  2016-01-02  njr   added calcCoef to SetTargetRatio functions that were in the ADSR widget but missing in this code
+//  1.02  2017-01-04  njr   in calcCoef, checked for rate 0, to support non-IEEE compliant compilers
+//  1.03  2020-04-08  njr   changed float to double; large target ratio and rate resulted in exp returning 1 in calcCoef
+//
+
+#ifndef ADRS_h
+#define ADRS_h
+
+
+class ADSR {
+public:
+	ADSR(void);
+	~ADSR(void);
+	double process(void);
+    double getOutput(void);
+    int getState(void);
+	void gate(int on);
+    void setAttackRate(double rate);
+    void setDecayRate(double rate);
+    void setReleaseRate(double rate);
+	void setSustainLevel(double level);
+    void setTargetRatioA(double targetRatio);
+    void setTargetRatioDR(double targetRatio);
+    void reset(void);
+
+    enum envState {
+        env_idle = 0,
+        env_attack,
+        env_decay,
+        env_sustain,
+        env_release
+    };
+
+protected:
+	int state;
+	double output;
+	double attackRate;
+	double decayRate;
+	double releaseRate;
+	double attackCoef;
+	double decayCoef;
+	double releaseCoef;
+	double sustainLevel;
+    double targetRatioA;
+    double targetRatioDR;
+    double attackBase;
+    double decayBase;
+    double releaseBase;
+ 
+    double calcCoef(double rate, double targetRatio);
+};
+
+inline double ADSR::process() {
+	switch (state) {
+        case env_idle:
+            break;
+        case env_attack:
+            output = attackBase + output * attackCoef;
+            if (output >= 1.0) {
+                output = 1.0;
+                state = env_decay;
+            }
+            break;
+        case env_decay:
+            output = decayBase + output * decayCoef;
+            if (output <= sustainLevel) {
+                output = sustainLevel;
+                state = env_sustain;
+            }
+            break;
+        case env_sustain:
+            break;
+        case env_release:
+            output = releaseBase + output * releaseCoef;
+            if (output <= 0.0) {
+                output = 0.0;
+                state = env_idle;
+            }
+	}
+	return output;
+}
+
+inline void ADSR::gate(int gate) {
+	if (gate)
+		state = env_attack;
+	else if (state != env_idle)
+        state = env_release;
+}
+
+inline int ADSR::getState() {
+    return state;
+}
+
+inline void ADSR::reset() {
+    state = env_idle;
+    output = 0.0;
+}
+
+inline double ADSR::getOutput() {
+	return output;
+}
+
+#endif

--- a/src/Common/dsp/freeverb/Makefile
+++ b/src/Common/dsp/freeverb/Makefile
@@ -1,0 +1,5 @@
+
+SOURCES = $(wildcard src/*.cpp src/freeverbsource/*.cpp)
+
+#include ../../../plugin.mk
+

--- a/src/Common/dsp/freeverb/allpass.hpp
+++ b/src/Common/dsp/freeverb/allpass.hpp
@@ -1,0 +1,80 @@
+// Allpass filter declaration
+//
+// Written by Jezar at Dreampoint, June 2000
+// http://www.dreampoint.co.uk
+// This code is public domain
+
+// adapted for use in VCV Rack by Martin Lueders
+
+#ifndef _allpass_
+#define _allpass_
+#include "denormals.h"
+
+class allpass
+{
+public:
+	allpass()
+	{
+		bufidx = 0;
+		buffer = 0;
+	};
+
+	~allpass()
+	{
+		if (buffer) delete buffer;
+	};
+
+        void    makebuffer(float *buf, int size)
+        {
+		if (buffer) delete buffer;
+                buffer = new float[size];
+                bufsize = size;
+		bufidx = 0;
+        }
+
+        void    deletebuffer()
+        {
+                if(buffer) delete buffer;
+                bufsize = 0;
+        };
+
+	void	setbuffer(float *buf, int size)
+	{
+		buffer = buf;
+		bufsize = size;
+	};
+
+	inline  float	process(float inp, float feedback);
+	void	mute()
+	{
+		for (int i=0; i<bufsize; i++) buffer[i] = 0.0;
+	};
+
+// private:
+	float	*buffer;
+	int	bufsize;
+	int	bufidx;
+};
+
+
+// Big to inline - but crucial for speed
+
+inline float allpass::process(float input, float feedback)
+{
+	float output;
+	float bufout;
+	
+	bufout = buffer[bufidx];
+//	undenormalise(bufout);
+	
+	output = -input + bufout;
+	buffer[bufidx] = input + (bufout*feedback);
+
+	if(++bufidx>=bufsize) bufidx = 0;
+
+	return output;
+}
+
+#endif//_allpass
+
+//ends

--- a/src/Common/dsp/freeverb/comb.hpp
+++ b/src/Common/dsp/freeverb/comb.hpp
@@ -1,0 +1,92 @@
+// Comb filter class declaration
+//
+// Written by Jezar at Dreampoint, June 2000
+// http://www.dreampoint.co.uk
+// This code is public domain
+
+// adapted for use in VCV Rack by Martin Lueders
+
+#ifndef _comb_
+#define _comb_
+
+#include "denormals.h"
+
+class comb
+{
+public:
+	comb() 
+	{
+		buffer = 0;
+		filterstore = 0;
+		bufidx = 0;
+	};
+
+	~comb()
+	{
+		if (buffer) delete buffer;
+	};
+
+	void    makebuffer(float *buf, int size) 
+	{
+		if (buffer) {delete buffer;}
+		buffer = new float[size];
+		bufsize = size;
+		bufidx = 0;
+	}
+
+	void	deletebuffer()
+	{
+		if(buffer) delete buffer;
+		bufsize = 0;
+	};
+
+	void	setbuffer(float *buf, int size)
+	{
+		buffer = buf;
+		bufsize = size;
+	};
+
+	inline  float	process(float inp, float damp1, float damp2, float feedback);
+	void	mute()
+	{
+		for( int i=0; i<bufsize; i++) buffer[i]=0.0;
+	};
+
+private:
+	float	filterstore;
+	float	*buffer;
+	int	bufsize;
+	int	bufidx;
+};
+
+
+// Big to inline - but crucial for speed
+
+inline float comb::process(float input, float damp1, float damp2, float feedback)
+{
+	float output;
+
+	output = buffer[bufidx]; // y[n-K]
+//	undenormalise(output);
+
+	filterstore *= damp1;
+	filterstore += (output*damp2);
+
+//  filterstore = damp1*filterstore + damp2*output;
+//  filterstore = damp1*filterstore + (1.0-damp1) * output;
+//	filterstore = output + damp1*(filterstore - output);
+
+
+
+//	undenormalise(filterstore);
+
+	buffer[bufidx] = input + (filterstore*feedback);
+
+	if(++bufidx>=bufsize) bufidx = 0;
+
+	return output;
+}
+
+#endif //_comb_
+
+//ends

--- a/src/Common/dsp/freeverb/denormals.h
+++ b/src/Common/dsp/freeverb/denormals.h
@@ -1,0 +1,15 @@
+// Macro for killing denormalled numbers
+//
+// Written by Jezar at Dreampoint, June 2000
+// http://www.dreampoint.co.uk
+// Based on IS_DENORMAL macro by Jon Watte
+// This code is public domain
+
+#ifndef _denormals_
+#define _denormals_
+
+#define undenormalise(sample) if(((*(unsigned int*)&sample)&0x7f800000)==0) sample=0.0f
+
+#endif//_denormals_
+
+//ends

--- a/src/Common/dsp/freeverb/readme.txt
+++ b/src/Common/dsp/freeverb/readme.txt
@@ -1,0 +1,67 @@
+Freeverb - Free, studio-quality reverb SOURCE CODE in the public domain
+-----------------------------------------------------------------------
+
+Written by Jezar at Dreampoint - http://www.dreampoint.co.uk
+
+
+Introduction
+------------
+
+Hello.
+
+I'll try to keep this "readme" reasonably small. There are few things in the world that I hate more than long "readme" files. Except "coding conventions" - but more on that later...
+
+In this zip file you will find two folders of C++ source code:
+
+"Components" - Contains files that should clean-compile ON ANY TYPE OF COMPUTER OR SYSTEM WHATSOEVER. It should not be necessary to make ANY changes to these files to get them to compile, except to make up for inadequacies of certain compilers. These files create three classes - a comb filter, an allpass filter, and a reverb model made up of a number of instances of the filters, with some features to control the filters at a macro level. You will need to link these classes into another program that interfaces with them. The files in the components drawer are completely independant, and can be built without dependancies on anything else. Because of the simple interface, it should be possible to interface these files to any system - VST, DirectX, anything - without changing them AT ALL.
+
+"FreeverbVST" - Contains a Steinberg VST implementation of this version of Freeverb, using the components in (surprise) the components folder. It was built on a PC but may compile properly for the Macintosh with no problems. I don't know - I don't have a Macintosh. If you've figured out how to compile the examples in the Steinberg VST Development Kit, then you should easilly figure out how to bring the files into a project and get it working in a few minutes. It should be very simple.
+
+Note that this version of Freeverb doesn't contain predelay, or any EQ. I thought that might make it difficult to understand the "reverb" part of the code. Once you figure out how Freeverb works, you should find it trivial to add such features with little CPU overhead.
+
+Also, the code in this version of Freeverb has been optimised. This has changed the sound *slightly*, but not significantly compared to how much processing power it saves.
+
+Finally, note that there is also a built copy of this version of Freeverb called "Freeverb3.dll" - this is a VST plugin for the PC. If you want a version for the Mac or anything else, then you'll need to build it yourself from the code.
+
+
+Technical Explanation
+---------------------
+
+Freeverb is a simple implementation of the standard Schroeder/Moorer reverb model. I guess the only reason why it sounds better than other reverbs, is simply because I spent a long while doing listening tests in order to create the values found in "tuning.h". It uses 8 comb filters on both the left and right channels), and you might possibly be able to get away with less if CPU power is a serious constraint for you. It then feeds the result of the reverb through 4 allpass filters on both the left and right channels. These "smooth" the sound. Adding more than four allpasses doesn't seem to add anything significant to the sound, and if you use less, the sound gets a bit "grainy". The filters on the right channel are slightly detuned compared to the left channel in order to create a stereo effect.
+
+Hopefully, you should find the code in the components drawer a model of brevity and clarity. Notice that I don't use any "coding conventions". Personally, I think that coding conventions suck. They are meant to make the code "clearer", but they inevitably do the complete opposite, making the code completely unfathomable. Anyone whose done Windows programming with its - frankly stupid - "Hungarian notation" will know exactly what I mean. Coding conventions typically promote issues that are irrelevant up to the status of appearing supremely important. It may have helped back people in the days when compilers where somewhat feeble in their type-safety, but not in the new millenium with advanced C++ compilers.
+
+Imagine if we rewrote the English language to conform to coding conventions. After all, The arguments should be just as valid for the English language as they are for a computer language. For example, we could put a lower-case "n" in front of every noun, a lower-case "p" in front of a persons name, a lower-case "v" in front of every verb, and a lower-case "a" in front of every adjective. Can you imagine what the English language would look like? All in the name of "clarity". It's just as stupid to do this for computer code as it would be to do it for the English language. I hope that the code for Freeverb in the components drawer demonstrates this, and helps start a movement back towards sanity in coding practices.
+
+
+Background
+----------
+
+Why is the Freeverb code now public domain? Simple. I only intended to create Freeverb to provide me and my friends with studio-quality reverb for free. I never intended to make any money out of it. However, I simply do not have the time to develop it any further. I'm working on a "concept album" at the moment, and I'll never finish it if I spend any more time programming. 
+
+In any case, I make more far money as a contract programmer - making Mobile Internet products - than I ever could writing plugins, so it simply doesn't make financial sense for me to spend any more time on it.
+
+Rather than give Freeverb to any particular individual or organisation to profit from it, I've decided to give it away to the internet community at large, so that quality, FREE (or at the very least, low-cost) reverbs can be developed for all platforms.
+
+Feel free to use the source code for Freeverb in any of your own products, whether they are also available for free, or even if they are commercial - I really don't mind. You may do with the code whatever you wish. If you use it in a product (whether commercial or not), it would be very nice of you, if you were to send me a copy of your product - although I appreciate that this isn't always possible in all circumstances.
+
+HOWEVER, please don't bug me with questions about how to use this code. I gave away Freeverb because I don't have time to maintain it. That means I *certainly* don't have time to answer questions about the source code, so please don't email questions to me. I *will* ignore them. If you can't figure the code for Freeverb out - then find somebody who can. I hope that either way, you enjoy experimenting with it.
+
+
+Disclaimer
+----------
+
+This software and source code is given away for free, without any warranties of any kind. It has been given away to the internet community as a free gift, so please treat it in the same spirit.
+
+
+I hope this code is useful and interesting to you all!
+I hope you have lots of fun experimenting with it and make good products!
+
+Very best regards,
+Jezar.
+Technology Consultant
+Dreampoint Design and Engineering
+http://www.dreampoint.co.uk
+
+
+//ends

--- a/src/Common/dsp/freeverb/revmodel.cpp
+++ b/src/Common/dsp/freeverb/revmodel.cpp
@@ -1,0 +1,233 @@
+// Reverb model implementation
+//
+// Written by Jezar at Dreampoint, June 2000
+// http://www.dreampoint.co.uk
+// This code is public domain
+
+// adapted for use in VCV Rack by Martin Lueders
+
+#include "revmodel.hpp"
+
+revmodel::revmodel()
+{
+};
+
+
+void revmodel::init(const float sampleRate)
+{
+
+	conversion = sampleRate/44100.0;
+
+	int ccombtuningL1 = round(conversion * combtuningL1);
+	int ccombtuningR1 = round(conversion * combtuningR1);
+	int ccombtuningL2 = round(conversion * combtuningL2);
+	int ccombtuningR2 = round(conversion * combtuningR2);
+	int ccombtuningL3 = round(conversion * combtuningL3);
+	int ccombtuningR3 = round(conversion * combtuningR3);
+	int ccombtuningL4 = round(conversion * combtuningL4);
+	int ccombtuningR4 = round(conversion * combtuningR4);
+	int ccombtuningL5 = round(conversion * combtuningL5);
+	int ccombtuningR5 = round(conversion * combtuningR5);
+	int ccombtuningL6 = round(conversion * combtuningL6);
+	int ccombtuningR6 = round(conversion * combtuningR6);
+	int ccombtuningL7 = round(conversion * combtuningL7);
+	int ccombtuningR7 = round(conversion * combtuningR7);
+	int ccombtuningL8 = round(conversion * combtuningL8);
+	int ccombtuningR8 = round(conversion * combtuningR8);
+
+	int callpasstuningL1 = round(conversion * allpasstuningL1);
+	int callpasstuningR1 = round(conversion * allpasstuningR1);
+	int callpasstuningL2 = round(conversion * allpasstuningL2);
+	int callpasstuningR2 = round(conversion * allpasstuningR2);
+	int callpasstuningL3 = round(conversion * allpasstuningL3);
+	int callpasstuningR3 = round(conversion * allpasstuningR3);
+	int callpasstuningL4 = round(conversion * allpasstuningL4);
+	int callpasstuningR4 = round(conversion * allpasstuningR4);
+
+	// Tie the components to their buffers
+	combL[0].makebuffer(bufcombL1,ccombtuningL1);
+	combR[0].makebuffer(bufcombR1,ccombtuningR1);
+	combL[1].makebuffer(bufcombL2,ccombtuningL2);
+	combR[1].makebuffer(bufcombR2,ccombtuningR2);
+	combL[2].makebuffer(bufcombL3,ccombtuningL3);
+	combR[2].makebuffer(bufcombR3,ccombtuningR3);
+	combL[3].makebuffer(bufcombL4,ccombtuningL4);
+	combR[3].makebuffer(bufcombR4,ccombtuningR4);
+	combL[4].makebuffer(bufcombL5,ccombtuningL5);
+	combR[4].makebuffer(bufcombR5,ccombtuningR5);
+	combL[5].makebuffer(bufcombL6,ccombtuningL6);
+	combR[5].makebuffer(bufcombR6,ccombtuningR6);
+	combL[6].makebuffer(bufcombL7,ccombtuningL7);
+	combR[6].makebuffer(bufcombR7,ccombtuningR7);
+	combL[7].makebuffer(bufcombL8,ccombtuningL8);
+	combR[7].makebuffer(bufcombR8,ccombtuningR8);
+
+	allpassL[0].makebuffer(bufallpassL1,callpasstuningL1);
+	allpassR[0].makebuffer(bufallpassR1,callpasstuningR1);
+	allpassL[1].makebuffer(bufallpassL2,callpasstuningL2);
+	allpassR[1].makebuffer(bufallpassR2,callpasstuningR2);
+	allpassL[2].makebuffer(bufallpassL3,callpasstuningL3);
+	allpassR[2].makebuffer(bufallpassR3,callpasstuningR3);
+	allpassL[3].makebuffer(bufallpassL4,callpasstuningL4);
+	allpassR[3].makebuffer(bufallpassR4,callpasstuningR4);
+
+	feedback_allpass = 0.5;
+
+	setwet(initialwet);
+	setroomsize(initialroom);
+	setdry(initialdry);
+	setdamp(initialdamp);
+	setwidth(initialwidth);
+	setmode(initialmode);
+
+
+	// Buffer will be full of rubbish - so we MUST mute them
+	mute();
+}
+
+
+void revmodel::mute()
+{
+	if (getmode() >= freezemode)
+		return;
+
+	for (int i=0;i<numcombs;i++)
+	{
+		combL[i].mute();
+		combR[i].mute();
+	}
+	for (int i=0;i<numallpasses;i++)
+	{
+		allpassL[i].mute();
+		allpassR[i].mute();
+	}
+}
+
+void revmodel::process(const float in, float &outputL, float &outputR)
+{
+	float outL,outR,input;
+
+	{
+		outL = outR = 0;
+		input = in*gain*conversion;
+
+		// Accumulate comb filters in parallel
+		for(int i=0; i<numcombs; i++)
+		{
+			outL += combL[i].process(input, damp1, damp2, roomsize1);
+			outR += combR[i].process(input, damp1, damp2, roomsize1);
+		}
+
+		// Feed through allpasses in series
+		for(int i=0; i<numallpasses; i++)
+		{
+			outL = allpassL[i].process(outL, feedback_allpass);
+			outR = allpassR[i].process(outR, feedback_allpass);
+		}
+
+		// Calculate output REPLACING anything already there
+		outputL = outL; //*wet1 + outR*wet2;
+		outputR = outR; //*wet1 + outL*wet2;
+
+	}
+}
+
+
+void revmodel::update()
+{
+// Recalculate internal values after parameter change
+
+
+	if (mode >= freezemode)
+	{
+		roomsize1 = 1;
+		damp1 = 0;
+		gain = muted;
+	}
+	else
+	{
+		roomsize1 = roomsize;
+		damp1 = damp;
+		gain = fixedgain;
+	}
+
+	damp2 = 1.0 - damp1;
+}
+
+// The following get/set functions are not inlined, because
+// speed is never an issue when calling them, and also
+// because as you develop the reverb model, you may
+// wish to take dynamic action when they are called.
+
+void revmodel::setroomsize(float value)
+{
+	roomsize = ((value*scaleroom) + offsetroom); // * conversion;
+	update();
+}
+
+float revmodel::getroomsize()
+{
+//	return (roomsize/conversion-offsetroom)/scaleroom;
+	return (roomsize-offsetroom)/scaleroom;
+}
+
+void revmodel::setdamp(float value)
+{
+	damp = value*scaledamp/conversion;
+	damp = value*scaledamp * sqrt(conversion) ;
+	update();
+}
+
+float revmodel::getdamp()
+{
+//	return conversion * damp/scaledamp;
+	return damp/scaledamp;
+}
+
+void revmodel::setwet(float value)
+{
+	wet = value*scalewet;
+	update();
+}
+
+float revmodel::getwet()
+{
+	return wet/scalewet;
+}
+
+void revmodel::setdry(float value)
+{
+	dry = value*scaledry;
+}
+
+float revmodel::getdry()
+{
+	return dry/scaledry;
+}
+
+void revmodel::setwidth(float value)
+{
+	width = value;
+	update();
+}
+
+float revmodel::getwidth()
+{
+	return width;
+}
+
+void revmodel::setmode(float value)
+{
+	mode = value;
+	update();
+}
+
+float revmodel::getmode()
+{
+	if (mode >= freezemode)
+		return 1;
+	else
+		return 0;
+}
+
+//ends

--- a/src/Common/dsp/freeverb/revmodel.hpp
+++ b/src/Common/dsp/freeverb/revmodel.hpp
@@ -1,0 +1,99 @@
+// Reverb model declaration
+//
+// Written by Jezar at Dreampoint, June 2000
+// http://www.dreampoint.co.uk
+// This code is public domain
+
+// adapted for use in VCV Rack by Martin Lueders
+
+#ifndef _revmodel_
+#define _revmodel_
+
+#include <math.h>
+
+#include "comb.hpp"
+#include "allpass.hpp"
+#include "tuning.h"
+
+class revmodel
+{
+public:
+	revmodel();
+
+	void	init(const float sampleRate);
+
+	void	mute();
+
+	void	process(const float input, float &outputL, float &outputR);
+
+	void	setroomsize(float value);
+	float	getroomsize();
+	void	setdamp(float value);
+	float	getdamp();
+	void	setwet(float value);
+	float	getwet();
+	void	setdry(float value);
+	float	getdry();
+	void	setwidth(float value);
+	float	getwidth();
+	void	setmode(float value);
+	float	getmode();
+private:
+	void	update();
+private:
+	float	gain;
+	float	roomsize,roomsize1;
+	float	damp,damp1, damp2;
+	float   feedback_allpass;
+	float	wet;
+	float	dry;
+	float	width;
+	float	mode;
+
+	float 	conversion;
+	// float math_e = 2.71828;
+
+	// The following are all declared inline 
+	// to remove the need for dynamic allocation
+	// with its subsequent error-checking messiness
+
+	// Comb filters
+	comb	combL[numcombs];
+	comb	combR[numcombs];
+
+	// Allpass filters
+	allpass	allpassL[numallpasses];
+	allpass	allpassR[numallpasses];
+
+	// Buffers for the combs
+	float	*bufcombL1;
+	float	*bufcombR1;
+	float	*bufcombL2;
+	float	*bufcombR2;
+	float	*bufcombL3;
+	float	*bufcombR3;
+	float	*bufcombL4;
+	float	*bufcombR4;
+	float	*bufcombL5;
+	float	*bufcombR5;
+	float	*bufcombL6;
+	float	*bufcombR6;
+	float	*bufcombL7;
+	float	*bufcombR7;
+	float	*bufcombL8;
+	float	*bufcombR8;
+
+	// Buffers for the allpasses
+	float	*bufallpassL1;
+	float	*bufallpassR1;
+	float	*bufallpassL2;
+	float	*bufallpassR2;
+	float	*bufallpassL3;
+	float	*bufallpassR3;
+	float	*bufallpassL4;
+	float	*bufallpassR4;
+};
+
+#endif//_revmodel_
+
+//ends

--- a/src/Common/dsp/freeverb/tuning.h
+++ b/src/Common/dsp/freeverb/tuning.h
@@ -1,0 +1,62 @@
+// Reverb model tuning values
+//
+// Written by Jezar at Dreampoint, June 2000
+// http://www.dreampoint.co.uk
+// This code is public domain
+
+#ifndef _tuning_
+#define _tuning_
+
+const int	numcombs	= 8;
+const int	numallpasses	= 4;
+const float	muted		= 0;
+//const float	fixedgain	= 0.015f;
+const float	fixedgain	= 0.025f;
+const float scalewet		= 3;
+const float scaledry		= 2;
+const float scaledamp		= 0.4f;
+//const float scaleroom		= 0.28f;
+const float scaleroom		= 0.30f;
+const float offsetroom		= 0.7f;
+const float initialroom		= 0.5f;
+const float initialdamp		= 0.5f;
+const float initialwet		= 1/scalewet;
+const float initialdry		= 0;
+const float initialwidth	= 1;
+const float initialmode		= 0;
+const float freezemode		= 0.5f;
+const int	stereospread	= 23;
+
+// These values assume 44.1KHz sample rate
+// they will probably be OK for 48KHz sample rate
+// but would need scaling for 96KHz (or other) sample rates.
+// The values were obtained by listening tests.
+const int combtuningL1		= 1116;
+const int combtuningR1		= 1116+stereospread;
+const int combtuningL2		= 1188;
+const int combtuningR2		= 1188+stereospread;
+const int combtuningL3		= 1277;
+const int combtuningR3		= 1277+stereospread;
+const int combtuningL4		= 1356;
+const int combtuningR4		= 1356+stereospread;
+const int combtuningL5		= 1422;
+const int combtuningR5		= 1422+stereospread;
+const int combtuningL6		= 1491;
+const int combtuningR6		= 1491+stereospread;
+const int combtuningL7		= 1557;
+const int combtuningR7		= 1557+stereospread;
+const int combtuningL8		= 1617;
+const int combtuningR8		= 1617+stereospread;
+const int allpasstuningL1	= 556;
+const int allpasstuningR1	= 556+stereospread;
+const int allpasstuningL2	= 441;
+const int allpasstuningR2	= 441+stereospread;
+const int allpasstuningL3	= 341;
+const int allpasstuningR3	= 341+stereospread;
+const int allpasstuningL4	= 225;
+const int allpasstuningR4	= 225+stereospread;
+
+#endif//_tuning_
+
+//ends
+

--- a/src/GrooveBox.cpp
+++ b/src/GrooveBox.cpp
@@ -17,6 +17,8 @@ using namespace groove_box;
 #include "Common/sample.hpp"
 #include "Common/common.hpp"
 #include "Common/submodules.hpp"
+#include "Common/DSP/ADSR.cpp"
+#include "Common/DSP/freeverb/revmodel.cpp"
 #include "Common/VoxglitchSamplerModule.hpp"
 #include "Common/VoxglitchSamplerModuleWidget.hpp"
 

--- a/src/GrooveBox/GrooveBox.hpp
+++ b/src/GrooveBox/GrooveBox.hpp
@@ -204,6 +204,8 @@ struct GrooveBox : VoxglitchSamplerModule
         case FUNCTION_REVERSE: value = selected_track->getReverse(step_number); break;
         case FUNCTION_PROBABILITY: value = selected_track->getProbability(step_number); break;
         case FUNCTION_LOOP: value = selected_track->getLoop(step_number); break;
+        case FUNCTION_ATTACK: value = selected_track->getAttack(step_number); break;
+        case FUNCTION_RELEASE: value = selected_track->getRelease(step_number); break;
         default: value = 0;
       }
 
@@ -290,6 +292,8 @@ struct GrooveBox : VoxglitchSamplerModule
           json_object_set(step_data, "reverse", json_real(this->memory_slots[memory_slot_number].tracks[track_number].getReverse(step_index)));
           json_object_set(step_data, "probability", json_real(this->memory_slots[memory_slot_number].tracks[track_number].getProbability(step_index)));
           json_object_set(step_data, "loop", json_real(this->memory_slots[memory_slot_number].tracks[track_number].getLoop(step_index)));
+          json_object_set(step_data, "attack", json_real(this->memory_slots[memory_slot_number].tracks[track_number].getAttack(step_index)));
+          json_object_set(step_data, "release", json_real(this->memory_slots[memory_slot_number].tracks[track_number].getRelease(step_index)));
 
           json_array_append_new(steps_json_array, step_data);
         }
@@ -417,6 +421,13 @@ struct GrooveBox : VoxglitchSamplerModule
 
                 json_t *loop_json = json_object_get(json_step_object, "loop");
                 if(loop_json) this->memory_slots[memory_slot_index].tracks[track_index].setLoop(step_index, json_real_value(loop_json));
+
+                json_t *attack_json = json_object_get(json_step_object, "attack");
+                if(attack_json) this->memory_slots[memory_slot_index].tracks[track_index].setAttack(step_index, json_real_value(attack_json));
+
+                json_t *release_json = json_object_get(json_step_object, "release");
+                if(release_json) this->memory_slots[memory_slot_index].tracks[track_index].setRelease(step_index, json_real_value(release_json));
+
               }
             }
           }
@@ -587,6 +598,8 @@ struct GrooveBox : VoxglitchSamplerModule
         case FUNCTION_REVERSE: selected_track->setReverse(step_number, value); break;
         case FUNCTION_PROBABILITY: selected_track->setProbability(step_number, value); break;
         case FUNCTION_LOOP: selected_track->setLoop(step_number, value); break;
+        case FUNCTION_ATTACK: selected_track->setAttack(step_number, value); break;
+        case FUNCTION_RELEASE: selected_track->setRelease(step_number, value); break;
       }
     }
 
@@ -770,8 +783,6 @@ struct GrooveBox : VoxglitchSamplerModule
   void detachExpander()
   {
     this->any_track_soloed = false;
-
-    // TODO: Iterate through all memory slots as well
 
     for(unsigned int i=0; i < NUMBER_OF_TRACKS; i++)
     {

--- a/src/GrooveBox/GrooveBox.hpp
+++ b/src/GrooveBox/GrooveBox.hpp
@@ -204,6 +204,7 @@ struct GrooveBox : VoxglitchSamplerModule
         case FUNCTION_REVERSE: value = selected_track->getReverse(step_number); break;
         case FUNCTION_PROBABILITY: value = selected_track->getProbability(step_number); break;
         case FUNCTION_LOOP: value = selected_track->getLoop(step_number); break;
+        default: value = 0;
       }
 
       params[STEP_KNOBS + step_number].setValue(value);

--- a/src/GrooveBox/GrooveBoxWidget.hpp
+++ b/src/GrooveBox/GrooveBoxWidget.hpp
@@ -49,14 +49,22 @@ float memory_slot_button_positions[NUMBER_OF_MEMORY_SLOTS][2] = {
 };
 
 float function_button_positions[NUMBER_OF_FUNCTIONS][2] = {
-  {18.8, 349},
-  {98, 349},
-  {177, 349},
-  {256, 349},
-  {335, 349},
-  {414, 349},
-  {493, 349},
-  {573, 349}
+  {18.8, 332.7667},
+  {98, 332.7667},
+  {177, 332.7667},
+  {256, 332.7667},
+  {335, 332.7667},
+  {414, 332.7667},
+  {493, 332.7667},
+  {573, 332.7667},
+  {18.8, 360.936},
+  {98, 360.936},
+  {177, 360.936},
+  {256, 360.936},
+  {335, 360.936},
+  {414, 360.936},
+  {493, 360.936},
+  {573, 360.936},
 };
 
 float track_button_positions[NUMBER_OF_TRACKS][2] = {
@@ -624,6 +632,7 @@ struct GrooveBoxWidget : VoxglitchSamplerModuleWidget
     {
       float x = function_button_positions[i][0];
       float y = function_button_positions[i][1];
+
       addParam(createParamCentered<LEDButton>(Vec(x, y), module, GrooveBox::FUNCTION_BUTTONS + i));
       addChild(createLightCentered<MediumLight<GreenLight>>(Vec(x, y), module, GrooveBox::FUNCTION_BUTTON_LIGHTS + i));
     }
@@ -642,7 +651,7 @@ struct GrooveBoxWidget : VoxglitchSamplerModuleWidget
       addChild(track_label_display);
     }
 
-    // Indivisual track outputs
+    // Individual track outputs
     for(unsigned int i=0; i<(NUMBER_OF_TRACKS * 2); i++)
     {
       addOutput(createOutputCentered<ModdedCL1362>(mm2px(Vec(10 + (i * 11), 6)), module, GrooveBox::TRACK_OUTPUTS + i));

--- a/src/GrooveBox/SamplePlaybackSettings.hpp
+++ b/src/GrooveBox/SamplePlaybackSettings.hpp
@@ -11,6 +11,8 @@ struct SamplePlaybackSettings
   float probability = default_probability;
   float loop = default_loop;
   bool reverse = default_reverse;
+  float attack = default_attack;
+  float release = default_release;
 
   void copy(SamplePlaybackSettings *src_settings)
   {
@@ -22,6 +24,8 @@ struct SamplePlaybackSettings
     this->probability = src_settings->probability;
     this->loop = src_settings->loop;
     this->reverse = src_settings->reverse;
+    this->attack = src_settings->attack;
+    this->release = src_settings->release;
   }
 };
 

--- a/src/GrooveBox/defines.h
+++ b/src/GrooveBox/defines.h
@@ -3,7 +3,7 @@ namespace groove_box
   const int NUMBER_OF_STEPS = 16;
   const int NUMBER_OF_TRACKS = 8;
   const int NUMBER_OF_MEMORY_SLOTS = 16;
-  const int NUMBER_OF_FUNCTIONS = 8;
+  const int NUMBER_OF_FUNCTIONS = 16;
   const int NUMBER_OF_OFFSET_SNAP_OPTIONS = 8;
   const int NUMBER_OF_RATCHET_PATTERNS = 16;
 

--- a/src/GrooveBox/defines.h
+++ b/src/GrooveBox/defines.h
@@ -15,6 +15,8 @@ namespace groove_box
   const int FUNCTION_PROBABILITY = 5;
   const int FUNCTION_LOOP = 6;
   const int FUNCTION_REVERSE = 7;
+  const int FUNCTION_ATTACK = 8;
+  const int FUNCTION_RELEASE = 9;
 
   const float default_volume = 0.5;
   const float default_pan = 0.5;
@@ -24,6 +26,9 @@ namespace groove_box
   const float default_probability = 1.0;
   const float default_loop = 0.0;
   const bool default_reverse = false;
+  const float default_attack = 0.0;
+  const float default_release = 1.0;
+  const float maximum_release_time = 4.0;
 
   const std::string PLACEHOLDER_TRACK_NAMES[NUMBER_OF_TRACKS] = {
     "kick_drum.wav",


### PR DESCRIPTION
This update:

- Added Attack and Release parameter locks
- Fixed bug where double clicking on the loop parameter locks did not reset them
- Fixed bug where reset always reset to step #1 regardless of the track start value
- Randomize no longer randomizes the master volume