### PR TITLE
Conversion of Wavbank to use SamplePlayer

### DIFF
--- a/src/WavBank/MenuItemLoadBank.hpp
+++ b/src/WavBank/MenuItemLoadBank.hpp
@@ -28,34 +28,4 @@ struct MenuItemLoadBank : MenuItem
       module->setRoot(path);
 		}
 	}
-
-  /*
-	void onAction(const event::Action &e) override
-	{
-		const std::string dir = wav_bank_module->rootDir;
-#ifdef USING_CARDINAL_NOT_RACK
-		WavBank *wav_bank_module = this->wav_bank_module;
-		async_dialog_filebrowser(false, dir.c_str(), text.c_str(), [wav_bank_module](char* path) {
-			if (path) {
-				if (char *rpath = strrchr(path, CARDINAL_OS_SEP))
-					*rpath = '\0';
-				pathSelected(wav_bank_module, path);
-			}
-		});
-#else
-		char *path = osdialog_file(OSDIALOG_OPEN_DIR, dir.c_str(), NULL, NULL);
-		pathSelected(wav_bank_module, path);
-#endif
-	}
-
-	static void pathSelected(WavBank *wav_bank_module, char *path)
-	{
-		if (path)
-		{
-			wav_bank_module->load_samples_from_path(path);
-			wav_bank_module->path = path;
-			free(path);
-		}
-	}
-  */
 };

--- a/src/WavBank/WavBankReadout.hpp
+++ b/src/WavBank/WavBankReadout.hpp
@@ -11,9 +11,9 @@ struct WavBankReadout : TransparentWidget
 		{
 			text_to_display = "";
 
-			if(module->samples.size() > module->selected_sample_slot)
+			if(module->sample_players.size() > module->selected_sample_slot)
 			{
-				text_to_display = module->samples[module->selected_sample_slot].filename;
+				text_to_display = module->sample_players[module->selected_sample_slot].getFilename();
 				text_to_display.resize(30); // truncate long text
 			}
 		}

--- a/src/wavbank.cpp
+++ b/src/wavbank.cpp
@@ -10,6 +10,7 @@
 #include "Common/VoxglitchSamplerModule.hpp"
 #include "Common/VoxglitchSamplerModuleWidget.hpp"
 #include "Common/dsp/DeclickFilter.hpp"
+#include "Common/SamplePlayer.hpp"
 
 #include "WavBank/defines.h"
 #include "WavBank/WavBank.hpp"


### PR DESCRIPTION
I spent some time making improvements to the Wavbank module, including:

- Internally, it now uses the SamplePlayback struct that most of my other sampler modules are using
- I fixed a bug where it could crash when attempting to playback a sample while a folder was being loaded
- Pitch now correctly responds using the 1v/octave standard