### PR TITLE
Updated GitHub Actions workflow so it works again.

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -3,7 +3,7 @@ on:
   [push, pull_request]
 
 env:
-  rack-sdk-version: 2.1.2
+  rack-sdk-version: 2.2.0
   rack-plugin-toolchain-dir: /home/build/rack-plugin-toolchain
 
 defaults:
@@ -35,8 +35,7 @@ jobs:
         run: |
           export PLUGIN_DIR=$GITHUB_WORKSPACE
           pushd ${{ env.rack-plugin-toolchain-dir }}
-          sed -i "s/-G 'MSYS Makefiles'/-DCMAKE_SYSTEM_NAME=Windows/g" Rack-SDK-win/dep.mk
-          make plugin-build-${{ matrix.platform }}
+          make plugin-build-${{ matrix.platform }}-x64
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
@@ -46,6 +45,10 @@ jobs:
   build-mac:
     name: mac
     runs-on: macos-12
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [x64, arm64]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -58,13 +61,15 @@ jobs:
       - name: Get Rack-SDK
         run: |
           pushd $HOME
-          curl -o Rack-SDK.zip https://vcvrack.com/downloads/Rack-SDK-${{ env.rack-sdk-version }}-mac.zip
+          curl -o Rack-SDK.zip https://vcvrack.com/downloads/Rack-SDK-${{ env.rack-sdk-version }}-mac-${{ matrix.platform }}.zip
           unzip Rack-SDK.zip
       - name: Build plugin
         run: |
           export RACK_DIR=$HOME/Rack-SDK
+          export CROSS_COMPILE=${{ matrix.platform }}
           make -j dep
           make -j dist
+          lipo -archs plugin.dylib
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
I noticed the Voxglitch build tests had started failing. Same thing happened for me in Sapphire. Based on recent changes made by BaconPaul et. al. to target the Rack SDK 2.2.0, and to add support for building for both Intel and ARM on Mac OS, I followed their changes to get it working again. This will allow you to verify Voxglitch builds correctly on all supported platforms again.

The tl;dr: now you will see a green check mark instead of red X when you push (unless there really is a problem you need to fix).