### PR TITLE
Adjust for Cardinal builds

### DIFF
--- a/res/ghosts/ghosts_panel.svg
+++ b/res/ghosts/ghosts_panel.svg
@@ -1,5 +1,5 @@
 <?xml version='1' encoding='utf-8'?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ns3="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" width="91.44mm" height="128.5mm" viewBox="0 0 91.44 128.5" version="1.1" id="svg11003" sodipodi:docname="ghosts_panel.svg">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:ns3="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" width="91.44mm" height="128.5mm" viewBox="0 0 91.44 128.5" version="1.1" id="svg11003" sodipodi:docname="ghosts_panel.svg">
   <defs id="defs10997">
     <rect x="232.5497" y="-26.5165" width="109.1596" height="49.3207" id="rect1322" />
     <rect x="33.9286" y="153.0357" width="82.1429" height="28.5714" id="rect509" />

--- a/src/OnePoint/OnePoint.hpp
+++ b/src/OnePoint/OnePoint.hpp
@@ -259,6 +259,7 @@ struct OnePoint : VoxglitchModule
         reset();
     }
 
+#ifndef USING_CARDINAL_NOT_RACK
     std::string selectFileVCV()
     {
         std::string filename_string = "";
@@ -274,4 +275,5 @@ struct OnePoint : VoxglitchModule
 
         return (filename_string);
     }
+#endif
 };

--- a/src/OnePoint/OnePointReadoutWidget.hpp
+++ b/src/OnePoint/OnePointReadoutWidget.hpp
@@ -57,8 +57,19 @@ struct OnePointReadoutWidget : TransparentWidget
 
     void onDoubleClick(const event::DoubleClick &e) override
     {
+#ifdef USING_CARDINAL_NOT_RACK
+        OnePoint *module = this->module;
+        async_dialog_filebrowser(false, NULL, NULL, "Open txt", [module](char* path) {
+            if (path != NULL) {
+                module->loadData(path);
+                module->path = path;
+            }
+            free(path);
+        });
+#else
       std::string path = module->selectFileVCV();
       module->loadData(path);
       module->path = path;
+#endif
     }
 };

--- a/src/OnePoint/OnePointWidget.hpp
+++ b/src/OnePoint/OnePointWidget.hpp
@@ -46,9 +46,20 @@ struct OnePointWidget : ModuleWidget
 
         void onAction(const event::Action &e) override
         {
+#ifdef USING_CARDINAL_NOT_RACK
+            OnePoint *module = this->module;
+            async_dialog_filebrowser(false, NULL, NULL, "Open txt", [module](char* path) {
+                if (path != NULL) {
+                    module->loadData(path);
+                    module->path = path;
+                }
+                free(path);
+            });
+#else
             std::string path = module->selectFileVCV();
             module->loadData(path);
             module->path = path;
+#endif
         }
     };
 

--- a/src/OneZero/OneZero.hpp
+++ b/src/OneZero/OneZero.hpp
@@ -280,6 +280,7 @@ struct OneZero : VoxglitchModule
 	}
     */
 
+#ifndef USING_CARDINAL_NOT_RACK
     std::string selectFileVCV()
     {
         std::string filename_string = "";
@@ -295,4 +296,5 @@ struct OneZero : VoxglitchModule
 
         return (filename_string);
     }
+#endif
 };

--- a/src/OneZero/OneZeroReadoutWidget.hpp
+++ b/src/OneZero/OneZeroReadoutWidget.hpp
@@ -57,8 +57,19 @@ struct OneZeroReadoutWidget : TransparentWidget
 
     void onDoubleClick(const event::DoubleClick &e) override
     {
+#ifdef USING_CARDINAL_NOT_RACK
+        OneZero *module = this->module;
+        async_dialog_filebrowser(false, NULL, NULL, "Open txt", [module](char* path) {
+            if (path != NULL) {
+                module->loadData(path);
+                module->path = path;
+            }
+            free(path);
+        });
+#else
       std::string path = module->selectFileVCV();
       module->loadData(path);
       module->path = path;
+#endif
     }
 };

--- a/src/OneZero/OneZeroWidget.hpp
+++ b/src/OneZero/OneZeroWidget.hpp
@@ -46,9 +46,20 @@ struct OneZeroWidget : ModuleWidget
 
         void onAction(const event::Action &e) override
         {
+#ifdef USING_CARDINAL_NOT_RACK
+            OneZero *module = this->module;
+            async_dialog_filebrowser(false, NULL, NULL, "Open txt", [module](char* path) {
+                if (path != NULL) {
+                    module->loadData(path);
+                    module->path = path;
+                }
+                free(path);
+            });
+#else
             std::string path = module->selectFileVCV();
             module->loadData(path);
             module->path = path;
+#endif
         }
     };
 


### PR DESCRIPTION
Needs only tweaking related to file dialog handling (Rack sync vs Cardinal async)

I changed a few call argument types to `const std::string&` for reducing the need to create a string copy.

Hopefully this is good and we can make the voxglitch update be part of Cardinal 24.09 release.